### PR TITLE
new jemalloc version

### DIFF
--- a/dune
+++ b/dune
@@ -53,7 +53,7 @@
   (optional)
   (libraries
     devkit_core
-    jemalloc_ctl)
+    jemalloc)
   (modules memory_jemalloc))
 
 (executable

--- a/memory_jemalloc.ml
+++ b/memory_jemalloc.ml
@@ -1,7 +1,7 @@
 (** Memory reporting for jemalloc, call [setup] in every binary linked with jemalloc *)
 
 open Devkit_core
-open Jemalloc_ctl
+open Jemalloc
 
 let show_crt_info () =
   let b = Action.bytes_string in


### PR DESCRIPTION
Hi,

I updated the project to use the new jemalloc version which change some name related stuff. (@jorisgio)

EDIT: the CI is probably going to fail until [opam-repository#14826](https://github.com/ocaml/opam-repository/pull/14826) is merged.

Cheers.