### PR TITLE
Add Github Action to build and test

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,9 +22,6 @@ jobs:
         ocaml-compiler: 4.13.1
         dune-cache: true
 
-    - name: Install OS deps
-      run: sudo apt update && sudo apt install -y libcurl4-gnutls-dev libevent-dev
-
     - name: Install OCaml deps
       run: opam install . --deps-only --with-test
       

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,35 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up OCaml
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.13.1
+        dune-cache: true
+
+    - name: Install OS deps
+      run: sudo apt update && sudo apt install -y libcurl4-gnutls-dev libevent-dev
+
+    - name: Install OCaml deps
+      run: opam install . --deps-only --with-test
+      
+    - name: Build
+      run: opam exec -- dune build
+
+    - name: Test
+      run: opam exec -- dune runtest

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: devkit
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 devkit
 ======
 
-[![Build Status](https://travis-ci.org/ahrefs/devkit.svg?branch=master)](https://travis-ci.org/ahrefs/devkit)
+[![Build Status](https://github.com/ahrefs/devkit/actions/workflows/makefile.yml/badge.svg)](https://github.com/ahrefs/devkit/actions/workflows/makefile.yml)
 
 General purpose OCaml library (development kit)
 Copyright (c) 2009 Ahrefs


### PR DESCRIPTION
Adds makefile.yml that triggers GitHub actions to build and test the code upon opening a PR against master or pushing to master. The check on the PR fails because of the use of a deprecated function in the ocaml code base. 