### PR TITLE
GitHub Action runner should run `apt update` before `apt get`

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -16,6 +16,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Update apt
+      run: sudo apt-get update
+
     - name: Set up OCaml
       uses: ocaml/setup-ocaml@v2
       with:


### PR DESCRIPTION
This PR resolves the CI error in #17 by running `apt update` in GitHub Action before setting up the OCaml environment, per https://github.com/actions/runner-images/issues/5470.