### PR TITLE
Tracing support in Web: both local tracing (via ocaml-trace) and W3C `traceparent` header support (via ocaml-opentelemetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,65 @@ General purpose OCaml library (development kit)
 Copyright (c) 2009 Ahrefs
 Released under the terms of LGPL-2.1 with OCaml linking exception.
 
-    opam install devkit
+Usage
+-----
+
+```sh
+opam install devkit
+```
+
+### Tracing
+
+Devkit's `Web` module includes both simple, configurable, local tracing support, as well as [distributed tracing][] support via OpenTelemetry.
+
+To use local tracing, we use the mechanism provided by [`ocaml-trace`][]: by default, the tracing calls in devkit are a no-op; but if the top-level application containing devkit installs and configures a "tracing backend" at runtime, then devkit's web-requests will each produce timed traces.
+
+> As an example, using `trace-tef` as a backend to produce a `json` file:
+>
+> ```ocaml
+> open Devkit
+>
+> let run () =
+>   let resp = Web.http_request `GET "http://icanhazip.com" in
+>   (* ... *)
+>
+> let () =
+>   Trace_tef.with_setup ~out:(`File "trace.json") () @@ fun () ->
+>   run ()
+> ```
+
+For distributed traces, you'll both need to configure an OpenTelemetry backend for `ocaml-trace` at runtime (to collect devkit's own traces); and you will most likely also want to ensure your own application's traces (using either `ocaml-trace` or the full `ocaml-opentelemetry`) are properly configured to correctly appear as the _parent_ of devkit's traces.
+
+Configuring an OpenTelemetry backend for the traces themselves is as simple wrapping your top-level application in a call to `Opentelemetry_trace.`[`setup_with_otel_backend`][] or the like. That will configure both OpenTelemetry's collector and the `ocaml-trace` backend.
+
+Then, to ensure that parentage is correctly propagated across your distributed architecture, devkit can produce a W3C Trace Context [`traceparent`] HTTP header. To ensure that it produces the _correct_ `traceparent`, however, we depend upon 'ambient context'. For this to function properly, you'll need to follow the [detailed instructions in the `ocaml-ambient-context` documentation][ambient-context installation].
+
+Once thus configured, devkit will check `Opentelemetry.Scope.`[`get_ambient_scope`][] before each HTTP request, and use the ambient tracing-span as the parent of the web-request's span; which will itself then be propagated to the remote service via the `traceparent` HTTP header.
+
+> As an example, if your top-level application is using Lwt, and using cohttp as the OpenTelemetry backend:
+>
+> ```ocaml
+> open Devkit
+>
+> let run () =
+>   let* resp = Web.http_request_lwt `GET "http://icanhazip.com" in
+>   (* ... *)
+>
+> let () =
+>   Ambient_context.set_storage_provider (Ambient_context_lwt.storage ()) ;
+>   Opentelemetry_trace.setup_with_otel_backend
+>     (Opentelemetry_client_cohttp_lwt.create_backend ())
+>   @@ fun () ->
+>   Lwt_main.run @@ fun () ->
+>   run ()
+> ```
+
+  [distributed tracing]: <https://opentelemetry.io/docs/concepts/signals/traces/> "OpenTelemetry: Traces"
+  [`ocaml-trace`]: <https://github.com/c-cube/ocaml-trace> "Simon Cruanes' ocaml-trace library"
+  [`setup_with_otel_backend`]: <https://v3.ocaml.org/p/opentelemetry/latest/doc/Opentelemetry_trace/index.html#val-setup_with_otel_backend> "ocaml-opentelemetry: Opentelemetry_trace.setup_with_otel_backend"
+  [`traceparent`]: <https://www.w3.org/TR/trace-context/#traceparent-header> "W3C Trace Context specification: § 3.2 Traceparent header"
+  [ambient-context installation]: <https://github.com/ELLIOTTCABLE/ocaml-ambient-context?tab=readme-ov-file#as-a-top-level-application> "ocaml-ambient-context: Installation (as a top-level application)"
+  [`get_ambient_scope`]: <https://v3.ocaml.org/p/opentelemetry/latest/doc/Opentelemetry/Scope/index.html#val-get_ambient_scope>
 
 Development
 -----------

--- a/devkit.opam
+++ b/devkit.opam
@@ -20,6 +20,9 @@ depends: [
   "ocurl" {>= "0.7.2"}
   "ocamlnet"
   "pcre"
+  "trace"
+  "opentelemetry"
+  "opentelemetry-lwt"
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}
   "lwt_ppx"

--- a/devkit.opam
+++ b/devkit.opam
@@ -20,9 +20,8 @@ depends: [
   "ocurl" {>= "0.7.2"}
   "ocamlnet"
   "pcre"
-  "ambient-context"
-  "trace"
-  "opentelemetry"
+  "trace" {>= "0.4" & < "0.5"}
+  "opentelemetry" {>= "0.5"}
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}
   "lwt_ppx"

--- a/devkit.opam
+++ b/devkit.opam
@@ -21,7 +21,7 @@ depends: [
   "ocamlnet"
   "pcre"
   "trace" {>= "0.4"}
-  "opentelemetry" {>= "0.5"}
+  "opentelemetry" {>= "0.6"}
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}
   "lwt_ppx"

--- a/devkit.opam
+++ b/devkit.opam
@@ -34,6 +34,7 @@ depends: [
 depopts: [
   "gperftools"
   "jemalloc"
+  "opentelemetry"
 ]
 conflicts: [
   "jemalloc" {< "0.2"}

--- a/devkit.opam
+++ b/devkit.opam
@@ -21,7 +21,6 @@ depends: [
   "ocamlnet"
   "pcre"
   "trace" {>= "0.4"}
-  "opentelemetry" {>= "0.6"}
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}
   "lwt_ppx"
@@ -38,5 +37,6 @@ depopts: [
 ]
 conflicts: [
   "jemalloc" {< "0.2"}
+  "opentelemetry" {< "0.6"}
 ]
 available: arch != "arm32" & arch != "x86_32"

--- a/devkit.opam
+++ b/devkit.opam
@@ -20,9 +20,9 @@ depends: [
   "ocurl" {>= "0.7.2"}
   "ocamlnet"
   "pcre"
+  "ambient-context"
   "trace"
   "opentelemetry"
-  "opentelemetry-lwt"
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}
   "lwt_ppx"

--- a/devkit.opam
+++ b/devkit.opam
@@ -20,7 +20,7 @@ depends: [
   "ocurl" {>= "0.7.2"}
   "ocamlnet"
   "pcre"
-  "trace" {>= "0.4" & < "0.5"}
+  "trace" {>= "0.4"}
   "opentelemetry" {>= "0.5"}
   "extunix" {>= "0.1.4"}
   "lwt" {>= "2.5.2"}

--- a/dune
+++ b/dune
@@ -19,7 +19,7 @@
     netstring
     pcre
     stdlib-shims
-    trace
+    trace.core
     opentelemetry
     opentelemetry.trace
     yojson

--- a/dune
+++ b/dune
@@ -20,9 +20,12 @@
     pcre
     stdlib-shims
     trace.core
-    opentelemetry
-    opentelemetry.trace
     yojson
+    (select
+     possibly_otel.ml
+     from
+     (opentelemetry opentelemetry.trace -> possibly_otel.real.ml)
+     (                                  -> possibly_otel.stub.ml))
     zip)
   (modules :standard \
            devkit

--- a/dune
+++ b/dune
@@ -19,9 +19,9 @@
     netstring
     pcre
     stdlib-shims
-    ambient-context
     trace
     opentelemetry
+    opentelemetry.trace
     yojson
     zip)
   (modules :standard \

--- a/dune
+++ b/dune
@@ -19,9 +19,9 @@
     netstring
     pcre
     stdlib-shims
+    ambient-context
     trace
     opentelemetry
-    opentelemetry-lwt
     yojson
     zip)
   (modules :standard \

--- a/dune
+++ b/dune
@@ -19,6 +19,9 @@
     netstring
     pcre
     stdlib-shims
+    trace
+    opentelemetry
+    opentelemetry-lwt
     yojson
     zip)
   (modules :standard \

--- a/possibly_otel.mli
+++ b/possibly_otel.mli
@@ -1,0 +1,11 @@
+module Otrace := Trace_core
+
+val get_traceparent : unit -> string option
+
+val enter_manual_span :
+  __FUNCTION__:string ->
+  __FILE__:string ->
+  __LINE__:int ->
+  ?data:(unit -> (string * Otrace.user_data) list) ->
+  string ->
+  Trace_core.explicit_span

--- a/possibly_otel.real.ml
+++ b/possibly_otel.real.ml
@@ -1,0 +1,23 @@
+module Otel = Opentelemetry
+
+let get_traceparent () =
+    let tracing_scope = Otel.Scope.get_ambient_scope () in
+
+    match tracing_scope with
+    | None -> None
+    | Some Otel.Scope.{ trace_id; span_id; _ } ->
+      let tp_value = Otel.Trace_context.Traceparent.to_value ~trace_id ~parent_id:span_id () in
+      Some (Otel.Trace_context.Traceparent.name ^ ": " ^ tp_value)
+
+let enter_manual_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ?data name =
+    let tracing_scope = Otel.Scope.get_ambient_scope () in
+
+    match tracing_scope with
+    | None ->
+      Trace_core.enter_manual_toplevel_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ?data name
+    | Some Otel.Scope.{ span_id; _ } ->
+      let otrace_espan = Trace_core.{
+        span = Opentelemetry_trace.Internal.otrace_of_otel span_id;
+        meta = Trace_core.Meta_map.empty
+      } in
+      Trace_core.enter_manual_sub_span ~parent:otrace_espan ~__FUNCTION__ ~__FILE__ ~__LINE__ ?data name

--- a/possibly_otel.stub.ml
+++ b/possibly_otel.stub.ml
@@ -1,0 +1,4 @@
+let get_traceparent () = None
+
+let enter_manual_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ?data name =
+  Trace_core.enter_manual_toplevel_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ?data name

--- a/web.ml
+++ b/web.ml
@@ -6,6 +6,8 @@ open Printf
 open Prelude
 open Control
 
+module Otel = Opentelemetry
+
 let log = Log.self
 
 (** percent-encode (convert space into %20) *)
@@ -119,6 +121,21 @@ module type CURL = sig
   val perform : Curl.t -> Curl.curlCode t
 end
 
+module type TRACING = sig
+  type 'a io
+  type span_id
+
+  val get_traceparent : unit -> string option
+
+  val enabled : unit -> bool
+
+  val with_span :
+    __FILE__ : string ->
+    __LINE__ : int ->
+    string ->
+    (span_id -> 'a io) -> 'a io
+end
+
 type ('body,'ret) http_request_ =
   ?ua:string ->
   ?timeout:int ->
@@ -168,7 +185,12 @@ let simple_result ?(is_ok=(fun code -> code / 100 = 2)) ?verbose = function
 
 let nr_http = ref 0
 
-module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with type 'a IO.t = 'a IO.t = struct
+module Http
+  (IO : IO_TYPE)
+  (Curl_IO : CURL with type 'a t = 'a IO.t)
+  (Tracing : TRACING with type 'a io = 'a IO.t)
+: HTTP with type 'a IO.t = 'a IO.t =
+struct
 
   module IO = IO
 
@@ -249,6 +271,14 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
   (* Don't use curl_setheaders when using ?headers option *)
   let http_request' ?ua ?timeout ?(verbose=false) ?(setup=ignore) ?timer ?max_size ?(http_1_0=false) ?headers ?body (action:http_action) url =
     let open Curl in
+    let action_name = string_of_http_action action in
+    let headers = match Tracing.get_traceparent () with
+    | None -> headers
+    | Some tp ->
+      let tp_header = Otel.Trace_context.Traceparent.name ^ ": " ^ tp in
+      Some (tp_header :: (Option.default [] headers))
+    in
+
     let set_body_and_headers h ct body =
       set_httpheader h (("Content-Type: "^ct) :: Option.default [] headers);
       set_postfields h body;
@@ -273,7 +303,7 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       | `GET | `DELETE | `CUSTOM _ -> ()
       | `POST | `PUT | `PATCH -> set_post h true
       end;
-      set_customrequest h (string_of_http_action action);
+      set_customrequest h action_name;
       if http_1_0 then set_httpversion h HTTP_VERSION_1_0;
       Option.may (set_timeout h) timeout;
       Option.may (set_useragent h) ua;
@@ -282,18 +312,18 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
     in
     let nr_http = incr nr_http; !nr_http in (* XXX atomic wrt ocaml threads *)
     if verbose then begin
-      let action = string_of_http_action action in
       let body = match body with
       | None -> ""
       | Some (`Form args) -> String.concat " " @@ List.map (fun (k,v) -> sprintf "%s=\"%s\"" k (Stre.shorten ~escape:true 64 v)) args
       | Some (`Raw (ct,body)) -> sprintf "%s \"%s\"" ct (Stre.shorten ~escape:true 64 body)
       | Some (`Chunked (ct,_f)) -> sprintf "%s chunked" ct
       in
-      log #info "%s #%d %s %s" action nr_http url body
+      log #info "%s #%d %s %s" action_name nr_http url body
     end;
     let t = new Action.timer in
     let result = if verbose then Some (verbose_curl_result nr_http action t) else None in
-    http_gets ~setup ?timer ?result ?max_size url
+    Tracing.with_span ~__FILE__ ~__LINE__ action_name @@ fun _span_id ->
+     http_gets ~setup ?timer ?result ?max_size url
 
   let http_request ?ua ?timeout ?verbose ?setup ?timer ?max_size ?http_1_0 ?headers ?body (action:http_action) url =
     http_request' ?ua ?timeout ?verbose ?setup ?timer ?max_size ?http_1_0 ?headers ?body action url >>= fun res ->
@@ -349,8 +379,56 @@ module Curl_lwt_for_http = struct
   include Curl_lwt
 end
 
-module Http_blocking = Http(IO_blocking)(Curl_blocking)
-module Http_lwt = Http(IO_lwt)(Curl_lwt_for_http)
+
+module Tracing_stack = struct
+  module TLS = Otel.Thread_local
+
+  type 'a io = 'a
+
+  type span_id = Trace.span
+
+  let _traceparent_key : string TLS.t = TLS.create ()
+
+  let get_traceparent () =
+    TLS.get _traceparent_key
+
+  let with_traceparent s cb =
+    TLS.with_ _traceparent_key s cb
+
+  let enabled = Trace.enabled
+
+  let with_span ~__FILE__ ~__LINE__ name cb =
+    let span_id = Trace.enter_span ~__FILE__ ~__LINE__ name in
+    let rv = cb span_id in
+    Trace.exit_span span_id;
+    rv
+end
+
+module Tracing_lwt = struct
+  type 'a io = 'a Lwt.t
+
+  type span_id = Otel.Span_id.t
+
+  let _traceparent_key : string Lwt.key = Lwt.new_key ()
+
+  let get_traceparent () =
+    Lwt.get _traceparent_key
+
+  let with_traceparent s cb =
+    Lwt.with_value _traceparent_key s cb
+
+  let enabled = Otel.Collector.has_backend
+
+  let with_span ~__FILE__ ~__LINE__ name cb =
+    log#warn "Attempt to trace at %s:%i; Http_lwt currently doesn't support async scopes during tracing; pending imandra-ai/ocaml-opentelemetry#32. Replace Tracing_lwt with your own scope-tracking implementation." __FILE__ __LINE__;
+    let attrs = [ "file", `String __FILE__; "line", `Int __LINE__ ] in
+    Opentelemetry_lwt.Trace.with_
+      ~attrs ~kind:Otel.Proto.Trace.Span_kind_client name
+      (fun scope -> cb scope.Otel.Scope.span_id)
+end
+
+module Http_blocking = Http(IO_blocking)(Curl_blocking)(Tracing_stack)
+module Http_lwt = Http(IO_lwt)(Curl_lwt_for_http)(Tracing_lwt)
 
 let with_curl = Http_blocking.with_curl
 let with_curl_cache = Http_blocking.with_curl_cache

--- a/web.ml
+++ b/web.ml
@@ -311,19 +311,19 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
     in
     let sid = match tracing_scope with
     | None ->
-      Trace.enter_manual_toplevel_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name
+      Trace_core.enter_manual_toplevel_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name
     | Some Otel.Scope.{ span_id; _ } ->
-      let otrace_espan = Trace.{
+      let otrace_espan = Trace_core.{
         span = Opentelemetry_trace.Internal.otrace_of_otel span_id;
-        meta = Trace.Meta_map.empty
+        meta = Trace_core.Meta_map.empty
       } in
-      Trace.enter_manual_sub_span ~parent:otrace_espan ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name
+      Trace_core.enter_manual_sub_span ~parent:otrace_espan ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name
     in
 
     let t = new Action.timer in
     let result = Some (fun h code ->
       if verbose then verbose_curl_result nr_http action t h code;
-      Trace.exit_manual_span sid;
+      Trace_core.exit_manual_span sid;
       return ()
     ) in
 

--- a/web.ml
+++ b/web.ml
@@ -272,6 +272,8 @@ struct
   let http_request' ?ua ?timeout ?(verbose=false) ?(setup=ignore) ?timer ?max_size ?(http_1_0=false) ?headers ?body (action:http_action) url =
     let open Curl in
     let action_name = string_of_http_action action in
+    Tracing.with_span ~__FILE__ ~__LINE__ action_name @@ fun _span_id ->
+
     let headers = match Tracing.get_traceparent () with
     | None -> headers
     | Some tp ->
@@ -322,8 +324,7 @@ struct
     end;
     let t = new Action.timer in
     let result = if verbose then Some (verbose_curl_result nr_http action t) else None in
-    Tracing.with_span ~__FILE__ ~__LINE__ action_name @@ fun _span_id ->
-     http_gets ~setup ?timer ?result ?max_size url
+    http_gets ~setup ?timer ?result ?max_size url
 
   let http_request ?ua ?timeout ?verbose ?setup ?timer ?max_size ?http_1_0 ?headers ?body (action:http_action) url =
     http_request' ?ua ?timeout ?verbose ?setup ?timer ?max_size ?http_1_0 ?headers ?body action url >>= fun res ->

--- a/web.ml
+++ b/web.ml
@@ -254,7 +254,7 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
 
     let headers = match tracing_scope with
     | None -> headers
-    | Some Opentelemetry.Scope.{ trace_id; span_id; _ } ->
+    | Some Otel.Scope.{ trace_id; span_id; _ } ->
       let tp_value = Otel.Trace_context.Traceparent.to_value ~trace_id ~parent_id:span_id () in
       let tp_header = Otel.Trace_context.Traceparent.name ^ ": " ^ tp_value in
       Some (tp_header :: (Option.default [] headers))
@@ -312,7 +312,7 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
     let sid = match tracing_scope with
     | None ->
       Trace.enter_manual_toplevel_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name
-    | Some Opentelemetry.Scope.{ span_id; _ } ->
+    | Some Otel.Scope.{ span_id; _ } ->
       let otrace_espan = Trace.{
         span = Opentelemetry_trace.Internal.otrace_of_otel span_id;
         meta = Trace.Meta_map.empty

--- a/web.ml
+++ b/web.ml
@@ -308,7 +308,7 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       [
         "otrace.spankind", `String "CLIENT";
         "http.request.method", `String action_name;
-        "url.ful", `String url;
+        "url.full", `String url;
       ]
     in
     Trace.with_span ~__FUNCTION__ ~__FILE__ ~__LINE__ ~data:describe action_name @@ fun _span_id ->


### PR DESCRIPTION
This implements support in the `Web` module for:

1. simple, local tracing (via [`ocaml-trace`](https://github.com/c-cube/ocaml-trace)), as well as
2. [distributed tracing](https://opentelemetry.io/docs/concepts/signals/traces/) in OpenTelemetry (through [`ocaml-opentelemetry`](https://github.com/imandra-ai/ocaml-opentelemetry) and [`ambient-context`](https://github.com/ELLIOTTCABLE/ocaml-ambient-context))

I've added thorough documentation to the new functionality in the devkit README, as well; this PR should be largely self-documenting.

----

Implementation details follow — there are two primary mechanisms involved:


### Configurable tracing

The _internal_ tracing, for the Devkit-consuming application or library, uses the `Trace` API (as documented in `ocaml-trace`.) The user needs to configure that themselves, which involves _what_ they want to happen with traces (dumped to a json-file in TEF format for i.e. `chrome://tracing`; sent to an OpenTelemetry collector; whatever.)

If the user does not configure tracing, this PR is a no-op — i.e. this is backwards-compatible.

### Distributed tracing & OpenTelemetry support

However, for devkit to _propagate_ traces into a distributed tracing system like OpenTelemetry, it needs details on span parentage — that is, if the consuming application is generating its _own_ spans, it's important that devkit's newly-created-spans for HTTP requests (which will then be propagated forward in a `traceparent` header) be recorded as 'children' of the user's existing spans.

This, also, requires configuration to function in most cases. This configuration is dicey, and is described in detail [in the `ocaml-ambient-context` README](https://github.com/ELLIOTTCABLE/ocaml-ambient-context?tab=readme-ov-file#as-a-top-level-application).

Here, the potential failure-mode is more subtle: if (and only if) the user 1. _does_ configure `ocaml-trace`, 2. _does not_ configure `ocaml-ambient-context` correctly, and 3. _does_ use Lwt or Eio or a similar cooperative-scheduling / asynchronous-execution mechanism that 'dumps the stack' occasionally, then Devkit will produce new tracing-spans with incorrect (or absent) parentage. (This could result in "orphaned" spans for `Devkit.Web.http_request` showing up in their tracing U.I., etc.)