### PR TITLE
Add Systemd.Daemon.manage

### DIFF
--- a/systemd.ml
+++ b/systemd.ml
@@ -57,13 +57,12 @@ module Daemon = struct
     [
       ("-loglevel", Arg.String Log.set_loglevels, " ([<facil|prefix*>=]debug|info|warn|error[,])+");
       ExtArg.may_str "logfile" Daemon.logfile "<file> Log file";
-      "-runas",
-        Arg.String (fun name -> try Daemon.runas := Some (Unix.getpwnam name) with exn -> Exn.fail ~exn "runas: unknown user %s" name),
-        "<user> run as specified user";
     ]
 
   let manage () =
     Daemon.foreground := true;
     Daemon.pidfile := None;
+    Daemon.runas := None;
+
     Daemon.manage ()
 end

--- a/systemd.ml
+++ b/systemd.ml
@@ -52,4 +52,18 @@ module Daemon = struct
 
   let listen_fds_lwt () =
     List.map Lwt_unix.of_unix_file_descr (listen_fds ())
+
+  let get_args () =
+    [
+      ("-loglevel", Arg.String Log.set_loglevels, " ([<facil|prefix*>=]debug|info|warn|error[,])+");
+      ExtArg.may_str "logfile" Daemon.logfile "<file> Log file";
+      "-runas",
+        Arg.String (fun name -> try Daemon.runas := Some (Unix.getpwnam name) with exn -> Exn.fail ~exn "runas: unknown user %s" name),
+        "<user> run as specified user";
+    ]
+
+  let manage () =
+    Daemon.foreground := true;
+    Daemon.pidfile := None;
+    Daemon.manage ()
 end

--- a/systemd.mli
+++ b/systemd.mli
@@ -26,4 +26,11 @@ module Daemon : sig
 
   (** Same as {!listen_fds} but return lwt file descriptors. *)
   val listen_fds_lwt : unit -> Lwt_unix.file_descr list
+
+  (** Similar to {!Daemon.get_args} but without the foregound and pidfile
+      option. *)
+  val get_args : unit -> (string * Arg.spec * string) list
+
+  (** Similar to {!Daemon.manage} but sets to run in the foreground. *)
+  val manage : unit -> unit
 end


### PR DESCRIPTION
When a service is managed by systemd, it doesn't make sense to follow the default setting of `Devkit.Daemon`, which is to fork a child to run in the background. I saw a few usages of the pattern:
```
    Daemon.foreground := true;
    Daemon.pidfile := None;
    Daemon.manage ()
```
so maybe we should move it to `devkit` as well. 

Alternatively, we can add checks to `Systemd.Daemon.booted` in `Daemon.manage` and skip irrelevant parts. 