### PR TITLE
ci: check ocaml 5

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -37,7 +37,7 @@ jobs:
       run: opam install . --deps-only --with-test
       
     - name: Build
-      run: opam exec -- dune build
+      run: opam exec -- dune build --profile=release
 
     - name: Test
-      run: opam exec -- dune runtest
+      run: opam exec -- dune runtest --profile=release

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -35,6 +35,9 @@ jobs:
 
     - name: Install OCaml deps
       run: opam install . --deps-only --with-test
+
+    - name: Pin libevent
+      run: opam pin add libevent --dev
       
     - name: Build
       run: opam exec -- dune build --profile=release

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -10,20 +10,28 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        ocaml-version:
+          - 4.14
+          - 5.1
+
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Update apt
       run: sudo apt-get update
 
-    - name: Set up OCaml
+    - name: Set up OCaml ${{ matrix.ocaml-version }}
       uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-compiler: 4.13.1
+        ocaml-compiler: ${{ matrix.ocaml-version }}
         dune-cache: true
+        opam-depext-flags: "--with-test"
+        allow-prerelease-opam: true
 
     - name: Install OCaml deps
       run: opam install . --deps-only --with-test


### PR DESCRIPTION
Make sure that devkit compiles on ocaml 5.

For now it depends on a unreleased version of libevent.

There is also a warning that would be nice to fix, but it's not blocking:

```
File "httpev.ml", line 146, characters 33-46:
146 |     match Unix.getsockopt_int fd Unix.SO_ERROR with
                                       ^^^^^^^^^^^^^
Alert deprecated: SO_ERROR
Use Unix.getsockopt_error instead.

File "httpev.ml", line 819, characters 57-70:
819 | let check_req req = match Unix.getsockopt_int req.socket Unix.SO_ERROR with 0 -> `Ok | n -> `Error n
                                                               ^^^^^^^^^^^^^
Alert deprecated: SO_ERROR
Use Unix.getsockopt_error instead.
```