### PR TITLE
add Gzip_io.string_lwt

### DIFF
--- a/dune
+++ b/dune
@@ -39,6 +39,7 @@
   (preprocess
     (per_module
       ((pps lwt_ppx)
+       gzip_io
        httpev
        logstash
        lwt_flag


### PR DESCRIPTION
Compressing body content of a big size can block the event loop, preventing other operations from proceeding concurrently. This PR introduces a `Gzip_io.string_lwt` function which should handle compression of large string data without blocking the event loop.

reference: https://git.ahrefs.com/ahrefs/monorepo/pull/18094#issuecomment-37750