### PR TITLE
web,otel: add url to span name

### DIFF
--- a/web.ml
+++ b/web.ml
@@ -302,9 +302,10 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       ]
     in
     let explicit_span =
+      let span_name = Printf.sprintf "%s %s" action_name url in
       (* We set the value of `__FUNCTION__` to preserve the build with OCaml < 4.12. *)
       Possibly_otel.enter_manual_span
-        ~__FUNCTION__:"Devkit.Web.Http.http_request'" ~__FILE__ ~__LINE__ ~data:describe action_name in
+        ~__FUNCTION__:"Devkit.Web.Http.http_request'" ~__FILE__ ~__LINE__ ~data:describe span_name in
 
     let headers = match Possibly_otel.Traceparent.get_ambient ~explicit_span () with
     | None -> headers


### PR DESCRIPTION
This PR suggests adding the `url` to the span name. This is not [spec-compliant](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.1/docs/http/http-spans.md#name)

> HTTP client spans have no http.route attribute since client-side instrumentation is not generally aware of the "route", and therefore HTTP client span names SHOULD be [{method}](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.1/docs/http/http-spans.md#method-placeholder).

But I think it's a nice QOL improvement. We get more information right away, instead of seeing a bunch of lines in Grafana with just the method name.

Showing the full url might be a bit verbose in some cases, I think ideally we should extract the different parts, but that would require parsing the url. And I guess adding a library like `uri` for this is not desirable?