### PR TITLE
parallel: add option to not revive upon clear termination

### DIFF
--- a/parallel.ml
+++ b/parallel.ml
@@ -283,11 +283,11 @@ let run_forks_simple ?(revive=false) ?wait_stop f args =
           match result with
           | Some (Unix.WEXITED 0) ->
             (* do not relaunch *)
-            ()
+            log #info "worker %d exited" pid;
           | _ ->
           match launch f x with
           | exception exn -> log #error ~exn "restart"
-          | pid' -> log #info "worker %d exited, replaced with %d" pid pid';
+          | pid' -> log #info "worker %d exited with non-zero status, replaced with %d" pid pid';
         end
       end;
       loop pause

--- a/parallel.ml
+++ b/parallel.ml
@@ -249,8 +249,13 @@ let run_forks_simple ?(revive=false) ?wait_stop f args =
   let launch f x =
     match Nix.fork () with
     | `Child ->
-      let () = try f x with exn -> log #error ~exn ~backtrace:true "worker failed" in
-      exit 0
+      begin try
+        f x;
+        exit 0
+      with exn ->
+        log #error ~exn ~backtrace:true "worker failed";
+        exit 1
+      end
     | `Forked pid -> Hashtbl.add workers pid x; pid
   in
   args |> List.iter (fun x -> let (_:int) = launch f x in ());

--- a/parallel.ml
+++ b/parallel.ml
@@ -263,7 +263,7 @@ let run_forks_simple ?(revive=false) ?wait_stop f args =
   let rec loop pause =
     Nix.sleep pause;
     let total = Hashtbl.length workers in
-    if total = 0 && not revive then
+    if total = 0 then
       log #info "All workers dead, stopping"
     else
     match Daemon.should_exit () with

--- a/parallel.mli
+++ b/parallel.mli
@@ -1,5 +1,10 @@
 (** Parallel *)
 
+type revive_mode =
+  | Never (** never revive worker *)
+  | On_failure (** revive when worker exits with non-zero code *)
+  | Always (** revive worker regardless of exit code *)
+
 (** Invoke function in a forked process and return result *)
 val invoke : ('a -> 'b) -> 'a -> unit -> 'b
 
@@ -9,9 +14,9 @@ val launch_forks : ('a -> unit) -> 'a list -> unit
 
 (** Launch forks for each element of the list and wait for all workers to finish.
   Pass exit signals to the workers, see {!Forks.stop} for the description of [wait_stop] parameter.
-  @param revive to keep workers running (restarting with same param if exited) [default: false]
+  @param revive to keep workers running (restarting with same param if exited) [default: Never]
 *)
-val run_forks : ?wait_stop:int -> ?revive:bool -> ?wait:int -> ?workers:int -> ('a -> unit) -> 'a list -> unit
+val run_forks : ?wait_stop:int -> ?revive:revive_mode -> ?wait:int -> ?workers:int -> ('a -> unit) -> 'a list -> unit
 
 (** Same as [run_forks] but do not fork for one worker *)
 val run_forks' : ('a -> unit) -> 'a list -> unit


### PR DESCRIPTION
The PR enriches the semantics of `Parallel.run_forks ~revive` with an option to only revive workers with non-zero exit status. Setting `~revive:Always` preserves the original behavior of `~revive:true`.

Success is naturally determined by the Unix exit status, so child processes now return 1 if they exit with an exception.

This is joint work with @yasunariw .