### PR TITLE
web: fix wrong otel parent scope

### DIFF
--- a/possibly_otel.mli
+++ b/possibly_otel.mli
@@ -2,7 +2,7 @@ module Otrace := Trace_core
 
 module Traceparent : sig
   val name : string
-  val get_ambient : unit -> string option
+  val get_ambient : ?explicit_span:Trace_core.explicit_span -> unit -> string option
 end
 
 val enter_manual_span :

--- a/possibly_otel.real.ml
+++ b/possibly_otel.real.ml
@@ -5,8 +5,12 @@ let (let*) o f = Option.map f o
 module Traceparent = struct
   let name = Trace_context.Traceparent.name
 
-  let get_ambient () =
+  let get_ambient ?explicit_span () =
     let* Scope.{ trace_id; span_id; _ } = Scope.get_ambient_scope () in
+    let span_id = match explicit_span with
+      | Some {Trace_core.span; _} -> Opentelemetry_trace.Internal.otel_of_otrace span
+      | None -> span_id 
+    in
     Trace_context.Traceparent.to_value ~trace_id ~parent_id:span_id ()
 end
 

--- a/possibly_otel.stub.ml
+++ b/possibly_otel.stub.ml
@@ -1,7 +1,7 @@
 module Traceparent = struct
   let name = "traceparent"
 
-  let get_ambient () = None
+  let get_ambient ?explicit_span:_ () = None
 end
 
 


### PR DESCRIPTION
We need to set the `span` in the `traceparent` header to be the one we explicitly create with `Possibly_otel.enter_manual_span`