### PR TITLE
Use Stdlib.raise and Lwt.reraise instead of Lwt.fail for better backtraces

### DIFF
--- a/daemon.ml
+++ b/daemon.ml
@@ -40,7 +40,7 @@ let wait_exit =
     Bind to should_exit_lwt only once, because every bind will create an immutable waiter on
     should_exit_lwt's sleeper, that is only removed after should_exit_lwt thread terminates.
   *)
-  let thread = lazy (Lwt.bind should_exit_lwt (fun () -> Lwt.fail ShouldExit)) in
+  let thread = lazy (Lwt.bind should_exit_lwt (fun () -> raise ShouldExit)) in
   fun () -> Lazy.force thread
 
 (** [break_lwt = Lwt.wrap break] *)

--- a/exn_lwt.ml
+++ b/exn_lwt.ml
@@ -9,4 +9,4 @@ let map f x = Lwt.try_bind (fun () -> f x) (fun r -> Lwt.return (`Ok r)) (fun ex
 
 let fail = Exn.fail
 
-let invalid_arg fmt = ksprintf Lwt.fail_invalid_arg fmt
+let invalid_arg fmt = ksprintf Stdlib.invalid_arg fmt

--- a/httpev.ml
+++ b/httpev.ml
@@ -606,7 +606,7 @@ let handle_lwt ?(single=false) fd k =
     let pause = 2. in
     log #error "too many open files, disabling accept for %s" (Time.duration_str pause);
     Lwt_unix.sleep pause
-  | `Exn Lwt.Canceled -> log #info "canceling accept loop"; Lwt.fail Lwt.Canceled
+  | `Exn (Lwt.Canceled as exn) -> log #info "canceling accept loop"; Lwt.reraise exn
   | `Exn exn -> log #warn ~exn "accept"; Lwt.return_unit
   | `Ok (fd,addr as peer) ->
     let task =

--- a/lwt_mark.ml
+++ b/lwt_mark.ml
@@ -119,7 +119,7 @@ let with_mark v f =
 let run_thread on_success on_failure func =
   match func () with
   | thr -> Lwt.on_any thr on_success on_failure; thr
-  | exception exn -> on_failure exn; Lwt.fail exn
+  | exception exn -> on_failure exn; Lwt.reraise exn
 
 let mark_or_orphan id =
   try Hashtbl.find marks id with Not_found -> orphan_mark

--- a/lwt_util.ml
+++ b/lwt_util.ml
@@ -54,7 +54,7 @@ let suppress_exn name cleanup t =
 let action name f x =
   log #info "action %s started" name;
   match%lwt f x with
-  | exception exn -> log #error ~exn "action %s aborted" name; Lwt.fail exn
+  | exception exn -> log #error ~exn "action %s aborted" name; Lwt.reraise exn
   | x -> log #info "action %s done" name; Lwt.return x
 
 let action_do name f = action name f ()

--- a/nix.ml
+++ b/nix.ml
@@ -308,7 +308,7 @@ let connect_lwt fd sockaddr =
   let open Lwt_unix in
   Lwt.catch
     (fun () -> connect fd sockaddr)
-    (function Unix_error (e, f, "") -> Lwt.fail (Unix_error (e, f, show_addr sockaddr)) | exn -> Lwt.fail exn)
+    (function Unix_error (e, f, "") -> raise (Unix_error (e, f, show_addr sockaddr)) | exn -> Lwt.reraise exn)
 
 let get_xdg_dir ~env dir =
   try Sys.getenv env with Not_found ->

--- a/web.ml
+++ b/web.ml
@@ -359,8 +359,8 @@ module IO_lwt = struct
   let bracket mresource destroy k =
     let%lwt resource = mresource in
     (k resource) [%finally destroy resource]
-  let fail = Exn_lwt.fail
-  let raise = Lwt.fail
+  let fail = Exn.fail
+  let raise = raise
   let sleep = Lwt_unix.sleep
   let map_s = Lwt_list.map_s
   let catch = Lwt.catch


### PR DESCRIPTION
Lwt's documentation reads:

> Whenever possible, it is recommended to use `raise exn` instead, as
> raise captures a backtrace, while `Lwt.fail` does not. If you call
> `raise exn` in a callback that is expected by Lwt to return a
> promise, Lwt will automatically wrap `exn` in a rejected promise,
> but the backtrace will have been recorded by the OCaml runtime.
>
> For example, `bind`'s second argument is a callback which returns a
> promise. And so it is recommended to use `raise` in the body of that
> callback.
>
> Use `Lwt.fail` only when you specifically want to create a rejected
> promise, to pass to another function, or store in a data structure.

See also https://github.com/mirage/ocaml-cohttp/pull/1079

Note: CI failures on OCaml 5 switches are unrelated to the changes in this PR. That issue is addressed in a separate PR: https://github.com/ahrefs/devkit/pull/35 