### PR TITLE
expose Pid.sanitize_name

### DIFF
--- a/pid.mli
+++ b/pid.mli
@@ -31,6 +31,7 @@ val parse_exn : string -> t
 
 (** {1 Current process identifier} *)
 
+val sanitize_name : string -> string
 val set_name : string -> unit
 val self : unit -> t
 val self_name : unit -> string


### PR DESCRIPTION
It is useful to expose the sanitize_name function for use in consumer code.