### PR TITLE
Treat chunks as HTTP 1.1

### DIFF
--- a/httpev_common.ml
+++ b/httpev_common.ml
@@ -136,35 +136,45 @@ let status_code : reply_status -> int = function
 
   | `Custom _ -> 999
 
-let show_http_reply : reply_status -> string = function
-  | `Ok -> "HTTP/1.1 200 OK"
-  | `Created -> "HTTP/1.0 201 Created"
-  | `Accepted -> "HTTP/1.0 202 Accepted"
-  | `No_content -> "HTTP/1.0 204 No Content"
+let show_status = function
+  | `Ok -> "200 OK"
+  | `Created -> "201 Created"
+  | `Accepted -> "202 Accepted"
+  | `No_content -> "204 No Content"
 
-  | `Moved -> "HTTP/1.0 301 Moved Permanently"
-  | `Found -> "HTTP/1.0 302 Found"
+  | `Moved -> "301 Moved Permanently"
+  | `Found -> "302 Found"
 
-  | `Bad_request -> "HTTP/1.0 400 Bad Request"
-  | `Unauthorized -> "HTTP/1.0 401 Unauthorized"
-  | `Payment_required -> "HTTP/1.0 402 Payment Required"
-  | `Forbidden -> "HTTP/1.0 403 Forbidden"
-  | `Not_found -> "HTTP/1.0 404 Not Found"
-  | `Method_not_allowed -> "HTTP/1.0 405 Method Not Allowed"
-  | `Not_acceptable -> "HTTP/1.0 406 Not Acceptable"
-  | `Conflict -> "HTTP/1.0 409 Conflict"
-  | `Length_required -> "HTTP/1.0 411 Length Required"
-  | `Request_too_large -> "HTTP/1.0 413 Request Entity Too Large"
-  | `I'm_a_teapot -> "HTTP/1.0 418 I'm a teapot"
-  | `Unprocessable_content -> "HTTP/1.0 422 Unprocessable Content"
-  | `Too_many_requests -> "HTTP/1.0 429 Too Many Requests"
+  | `Bad_request -> "400 Bad Request"
+  | `Unauthorized -> "401 Unauthorized"
+  | `Payment_required -> "402 Payment Required"
+  | `Forbidden -> "403 Forbidden"
+  | `Not_found -> "404 Not Found"
+  | `Method_not_allowed -> "405 Method Not Allowed"
+  | `Not_acceptable -> "406 Not Acceptable"
+  | `Conflict -> "409 Conflict"
+  | `Length_required -> "411 Length Required"
+  | `Request_too_large -> "413 Request Entity Too Large"
+  | `I'm_a_teapot -> "418 I'm a teapot"
+  | `Unprocessable_content -> "422 Unprocessable Content"
+  | `Too_many_requests -> "429 Too Many Requests"
 
-  | `Internal_server_error -> "HTTP/1.0 500 Internal Server Error"
-  | `Not_implemented -> "HTTP/1.0 501 Not Implemented"
-  | `Service_unavailable -> "HTTP/1.0 503 Service Unavailable"
-  | `Version_not_supported -> "HTTP/1.0 505 HTTP Version Not Supported"
+  | `Internal_server_error -> "500 Internal Server Error"
+  | `Not_implemented -> "501 Not Implemented"
+  | `Service_unavailable -> "503 Service Unavailable"
+  | `Version_not_supported -> "505 HTTP Version Not Supported"
 
   | `Custom s -> s
+
+let show_http_reply : ?version:int * int -> reply_status -> string =
+ fun ?(version = (1, 0)) reply_status ->
+  let http_version =
+    match version with
+    | 1, 0 -> "HTTP/1.0"
+    | 1, 1 -> "HTTP/1.1"
+    | _ -> "HTTP/1.0"
+  in
+  sprintf "%s %s" http_version (show_status reply_status)
 
 (* basically allow all *)
 let cors_preflight_allow_all = (`No_content, [

--- a/httpev_common.ml
+++ b/httpev_common.ml
@@ -136,36 +136,6 @@ let status_code : reply_status -> int = function
 
   | `Custom _ -> 999
 
-let show_status = function
-  | `Ok -> "200 OK"
-  | `Created -> "201 Created"
-  | `Accepted -> "202 Accepted"
-  | `No_content -> "204 No Content"
-
-  | `Moved -> "301 Moved Permanently"
-  | `Found -> "302 Found"
-
-  | `Bad_request -> "400 Bad Request"
-  | `Unauthorized -> "401 Unauthorized"
-  | `Payment_required -> "402 Payment Required"
-  | `Forbidden -> "403 Forbidden"
-  | `Not_found -> "404 Not Found"
-  | `Method_not_allowed -> "405 Method Not Allowed"
-  | `Not_acceptable -> "406 Not Acceptable"
-  | `Conflict -> "409 Conflict"
-  | `Length_required -> "411 Length Required"
-  | `Request_too_large -> "413 Request Entity Too Large"
-  | `I'm_a_teapot -> "418 I'm a teapot"
-  | `Unprocessable_content -> "422 Unprocessable Content"
-  | `Too_many_requests -> "429 Too Many Requests"
-
-  | `Internal_server_error -> "500 Internal Server Error"
-  | `Not_implemented -> "501 Not Implemented"
-  | `Service_unavailable -> "503 Service Unavailable"
-  | `Version_not_supported -> "505 HTTP Version Not Supported"
-
-  | `Custom s -> s
-
 let show_http_reply : ?version:int * int -> reply_status -> string =
  fun ?(version = (1, 0)) reply_status ->
   let http_version =
@@ -174,7 +144,35 @@ let show_http_reply : ?version:int * int -> reply_status -> string =
     | 1, 1 -> "HTTP/1.1"
     | _ -> "HTTP/1.0"
   in
-  sprintf "%s %s" http_version (show_status reply_status)
+  match reply_status with
+  | `Ok -> sprintf "%s 200 OK" http_version
+  | `Created -> sprintf "%s 201 Created" http_version
+  | `Accepted -> sprintf "%s 202 Accepted" http_version
+  | `No_content -> sprintf "%s 204 No Content" http_version
+
+  | `Moved -> sprintf "%s 301 Moved Permanently" http_version
+  | `Found -> sprintf "%s 302 Found" http_version
+
+  | `Bad_request -> sprintf "%s 400 Bad Request" http_version
+  | `Unauthorized -> sprintf "%s 401 Unauthorized" http_version
+  | `Payment_required -> sprintf "%s 402 Payment Required" http_version
+  | `Forbidden -> sprintf "%s 403 Forbidden" http_version
+  | `Not_found -> sprintf "%s 404 Not Found" http_version
+  | `Method_not_allowed -> sprintf "%s 405 Method Not Allowed" http_version
+  | `Not_acceptable -> sprintf "%s 406 Not Acceptable" http_version
+  | `Conflict -> sprintf "%s 409 Conflict" http_version
+  | `Length_required -> sprintf "%s 411 Length Required" http_version
+  | `Request_too_large -> sprintf "%s 413 Request Entity Too Large" http_version
+  | `I'm_a_teapot -> sprintf "%s 418 I'm a teapot" http_version
+  | `Unprocessable_content -> sprintf "%s 422 Unprocessable Content" http_version
+  | `Too_many_requests -> sprintf "%s 429 Too Many Requests" http_version
+
+  | `Internal_server_error -> sprintf "%s 500 Internal Server Error" http_version
+  | `Not_implemented -> sprintf "%s 501 Not Implemented" http_version
+  | `Service_unavailable -> sprintf "%s 503 Service Unavailable" http_version
+  | `Version_not_supported -> sprintf "%s 505 HTTP Version Not Supported" http_version
+
+  | `Custom s -> s
 
 (* basically allow all *)
 let cors_preflight_allow_all = (`No_content, [

--- a/httpev_common.ml
+++ b/httpev_common.ml
@@ -137,7 +137,7 @@ let status_code : reply_status -> int = function
   | `Custom _ -> 999
 
 let show_http_reply : reply_status -> string = function
-  | `Ok -> "HTTP/1.0 200 OK"
+  | `Ok -> "HTTP/1.1 200 OK"
   | `Created -> "HTTP/1.0 201 Created"
   | `Accepted -> "HTTP/1.0 202 Accepted"
   | `No_content -> "HTTP/1.0 204 No Content"


### PR DESCRIPTION
HTTP 1.1 adds `Transfer-Encoding: chunked` which is needed to stream HTML
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Transfer-Encoding#chunked

I updated only the case of `Chunks` and didn't want to touch the sync (`Body`) since I suspect may cause issues. We could deploy staging with 1.1 enabled in the meantime.