### PR TITLE
switch from pcre to pcre2

### DIFF
--- a/devkit.opam
+++ b/devkit.opam
@@ -18,7 +18,7 @@ depends: [
   "camlzip"
   "libevent" {>= "0.8.0"}
   "ocurl" {>= "0.7.2"}
-  "pcre" {>= "7.4.6"}
+  "pcre2" {>= "8.0.3"}
   "trace" {>= "0.4"}
   "extunix" {>= "0.1.4"}
   "lwt" {>= "5.7.0"}

--- a/dune
+++ b/dune
@@ -17,7 +17,7 @@
     lwt
     lwt.unix
     ocamlnet_lite
-    pcre
+    pcre2
     stdlib-shims
     str
     trace.core

--- a/exn.ml
+++ b/exn.ml
@@ -16,15 +16,14 @@ let to_string exn =
   match exn with
   | Unix.Unix_error (e,f,s) -> sprintf "Unix_error %s(%s) %s" f s (Unix.error_message e)
   | Curl.CurlException (_,n,s) -> sprintf "Curl.CurlException(%u,%s)" n s
-  | Pcre.Error err -> sprintf "Pcre.Error(%s)"
+  | Pcre2.Error err -> sprintf "Pcre2.Error(%s)"
     begin match err with
     | Partial -> "Partial"
-    | BadPartial -> "BadPartial"
     | BadPattern(m,p) -> sprintf "BadPattern(%s,%i)" m p
-    | BadUTF8 -> "BadUTF8"
-    | BadUTF8Offset -> "BadUTF8Offset"
+    | BadUTF -> "BadUTF"
+    | BadUTFOffset -> "BadUTFOffset"
     | MatchLimit -> "MatchLimit"
-    | RecursionLimit -> "RecursionLimit"
+    | DepthLimit -> "DepthLimit"
     | InternalError s -> sprintf "InternalError(%s)" s
     | _ -> Printexc.to_string exn
     end

--- a/httpev.ml
+++ b/httpev.ml
@@ -163,7 +163,7 @@ let show_client c =
 
 type ('a,'b) result = [ `Ok of 'a | `Error of 'b ]
 
-let space = Pcre.regexp "[ \t]+"
+let space = Pcre2.regexp "[ \t]+"
 
 type reason = Url | Version | Method | Header | RequestLine | Split | Extra | NotAcceptable
 exception Parse of reason * string
@@ -209,7 +209,7 @@ let acceptable_encoding headers =
   | None -> Identity
 
 let make_request_exn ~line1 ~headers ~body c =
-  match Pcre.split ~rex:space line1 with
+  match Pcre2.split ~rex:space line1 with
   | [meth;url;version] ->
     if url.[0] <> '/' then (* abs_path *)
       failed Url url;

--- a/ocamlnet_lite/dune
+++ b/ocamlnet_lite/dune
@@ -3,5 +3,5 @@
  (public_name devkit.ocamlnet_lite)
  (libraries
   extlib ; just for Array.create
-  pcre
+  pcre2
   str))

--- a/ocamlnet_lite/netstring_str.ml
+++ b/ocamlnet_lite/netstring_str.ml
@@ -56,9 +56,9 @@ type re_term =
 (**********************************************************************)
 (* Final types *)
 
-type regexp = Pcre.regexp
+type regexp = Pcre2.regexp
 type split_result = Str.split_result = Text of string | Delim of string
-type result = Pcre.substrings
+type result = Pcre2.substrings
 
 (**********************************************************************)
 (* Parse Str-style regexps, and convert to Pcre-style regexps *)
@@ -268,9 +268,9 @@ let pcre_safe_quote c =
 
 let rec print_pcre_regexp ret =
   match ret with
-  | Texact s -> Pcre.quote s
+  | Texact s -> Pcre2.quote s
   | Tnullchar ->
-      (* Pcre.quote "\000" returns nonsense *)
+      (* Pcre2.quote "\000" returns nonsense *)
       "[\\000]"
   | Tany -> "."
   | Tnull -> "(?:)"
@@ -315,42 +315,42 @@ and print_set s =
 let regexp s =
   let ret = scan_str_regexp s in
   let s' = print_pcre_regexp ret in
-  Pcre.regexp ~flags:[ `MULTILINE ] s'
+  Pcre2.regexp ~flags:[ `MULTILINE ] s'
 
 let search_forward pat s pos =
-  let result = Pcre.exec ~rex:pat ~pos s in
-  (fst (Pcre.get_substring_ofs result 0), result)
+  let result = Pcre2.exec ~rex:pat ~pos s in
+  (fst (Pcre2.get_substring_ofs result 0), result)
 
 let matched_string result _ =
-  (* Unfortunately, Pcre.get_substring will not raise Not_found if there is
+  (* Unfortunately, Pcre2.get_substring will not raise Not_found if there is
    * no matched string. Instead, it returns "", but this value cannot be
    * distinguished from an empty match.
-   * The workaround is to call Pcre.get_substring_ofs first. This function
+   * The workaround is to call Pcre2.get_substring_ofs first. This function
    * will raise Not_found if there is not any matched string.
    *
    * NOTE: Current versions of Pcre do return Not_found!
    *)
-  ignore (Pcre.get_substring_ofs result 0);
-  Pcre.get_substring result 0
+  ignore (Pcre2.get_substring_ofs result 0);
+  Pcre2.get_substring result 0
 
-let match_beginning result = fst (Pcre.get_substring_ofs result 0)
-let match_end result = snd (Pcre.get_substring_ofs result 0)
+let match_beginning result = fst (Pcre2.get_substring_ofs result 0)
+let match_end result = snd (Pcre2.get_substring_ofs result 0)
 
 let matched_group result n _ =
   (* See also the comment for [matched_string] *)
-  if n < 0 || n >= Pcre.num_of_subs result then raise Not_found;
-  ignore (Pcre.get_substring_ofs result n);
-  Pcre.get_substring result n
+  if n < 0 || n >= Pcre2.num_of_subs result then raise Not_found;
+  ignore (Pcre2.get_substring_ofs result n);
+  Pcre2.get_substring result n
 
 let global_substitute pat subst s =
-  Pcre.substitute_substrings ~rex:pat ~subst:(fun r -> subst r s) s
+  Pcre2.substitute_substrings ~rex:pat ~subst:(fun r -> subst r s) s
 
 let tr_split_result r =
   List.map
     (function
-      | Pcre.Text t -> Text t | Pcre.Delim d -> Delim d | _ -> assert false)
+      | Pcre2.Text t -> Text t | Pcre2.Delim d -> Delim d | _ -> assert false)
     (List.filter
-       (function Pcre.Group (_, _) | Pcre.NoGroup -> false | _ -> true)
+       (function Pcre2.Group (_, _) | Pcre2.NoGroup -> false | _ -> true)
        r)
 
-let full_split sep s = tr_split_result (Pcre.full_split ~rex:sep ~max:(-1) s)
+let full_split sep s = tr_split_result (Pcre2.full_split ~rex:sep ~max:(-1) s)

--- a/stre.ml
+++ b/stre.ml
@@ -4,10 +4,10 @@ open Printf
 open ExtLib
 open Prelude
 
-let by_words = Pcre.regexp ~flags:[`UTF8] "[^\\pL\\pN.]+"
-let by_space = Pcre.regexp "\\s+"
-let by_lines = Pcre.regexp "\\r?\\n"
-let split rex str = match Pcre.split ~rex str with ""::l -> l | l -> l
+let by_words = Pcre2.regexp ~flags:[`UTF] "[^\\pL\\pN.]+"
+let by_space = Pcre2.regexp "\\s+"
+let by_lines = Pcre2.regexp "\\r?\\n"
+let split rex str = match Pcre2.split ~rex str with ""::l -> l | l -> l
 
 let nsplitc_enum str sep =
   let p = ref 0 in
@@ -100,14 +100,14 @@ let divide s sep = try String.split s sep with Invalid_string -> s, ""
 let dividec s sep = try splitc s sep with Not_found -> s, ""
 
 let qreplace str sub by =
-  Pcre.qreplace ~rex:(Pcre.regexp @@ Pcre.quote sub) ~templ:by str
+  Pcre2.qreplace ~rex:(Pcre2.regexp @@ Pcre2.quote sub) ~templ:by str
 
 let replace_all ~str ~sub ~by = qreplace str sub by
 
 (** contents of the first submatch *)
 let extract rex str =
   try
-    Some (Pcre.extract ~rex ~full_match:false str).(0)
+    Some (Pcre2.extract ~rex ~full_match:false str).(0)
   with
     _ -> None
 
@@ -158,11 +158,11 @@ let iexists s sub =
 (** sequence of matches *)
 let enum_matches rex s =
   try
-    Pcre.exec_all ~rex s |> Array.enum
+    Pcre2.exec_all ~rex s |> Array.enum
   with
     _ -> Enum.empty ()
 
-let enum_extract rex s = enum_matches rex s |> Enum.map (flip Pcre.get_substring 1)
+let enum_extract rex s = enum_matches rex s |> Enum.map (flip Pcre2.get_substring 1)
 
 module ASCII = struct
 let is_alpha = function


### PR DESCRIPTION
This switch to Pcre2 which is still maintained, and also faster according to my [benchmark](https://github.com/ahrefs/rebench).

The interface is remarkably similar. Relevant differences are:

- `` `UTF8`` becomes `` `UTF``
- The error constructors are not the same.