### PR TITLE
prelude: don't set Lwt_engine to poll if libev is available

### DIFF
--- a/prelude.ml
+++ b/prelude.ml
@@ -54,3 +54,13 @@ let call_me_maybe f x =
   match f with
   | None -> ()
   | Some f -> f x
+
+(*
+  If libev backend is available, do nothing (lwt uses it as default).
+  Otherwise, prefer poll over select, because select can only monitor fds up to 1024,
+  and poll is guaranteed to be available without the fd limitation.
+*)
+let () =
+  if not (Lwt_config._HAVE_LIBEV && Lwt_config.libev_default) then begin
+    Lwt_engine.set @@ new Lwt_engines.poll
+  end


### PR DESCRIPTION
Setting the lwt engine to poll at the top level here causes unexpected behavior when the library is used. On Linux, it overrides the default engine, which is libev.