### PR TITLE
[Action.config_lines] document and test behavior of commented lines

### DIFF
--- a/action.mli
+++ b/action.mli
@@ -185,9 +185,16 @@ val io_null : unit IO.output
 val file_lines_exn : string -> string list
 val file_lines : string -> string list
 
-(** read lines from file skipping empty lines and comments (lines starting with '#') *)
+(** Read lines from file skipping empty lines and comments (lines starting with '#').
+
+    Moreover, comments are stripped from lines (all characters
+    including and following a '#') and returned lines are trimmed. *)
 val make_config_lines : string list -> string list
 val config_lines_exn : string -> string list
+
+(** [config_lines file] read [file] and return the config lines.
+
+    See {!make_config_lines} for details on config lines. *)
 val config_lines : string -> string list
 
 

--- a/test.ml
+++ b/test.ml
@@ -544,6 +544,28 @@ let () = test "Web.urlencode" @@ fun () ->
   assert_equal (Web.urlencode "Hello Günter") "Hello+G%C3%BCnter";
   ()
 
+let () = test "Action.make_config_lines" @@ fun () ->
+  let config_lines = [
+    "";
+    "foobar";
+    "# only comment line";
+    "arg # a comment";
+    "test # comment1 # comment2 ";
+    "  test # comment ";
+    "foo";
+    "  baz";
+    "bar  ";
+  ] in
+  assert_equal ~printer:(Stre.list (Printf.sprintf "%S")) (Action.make_config_lines config_lines) [
+    "foobar";
+    "arg";
+    "test";
+    "test";
+    "foo";
+    "baz";
+    "bar"
+  ]
+
 let () =
   let open Lwt.Syntax in
   let rec pings f = function


### PR DESCRIPTION
# What

Clarify that `Action.config_lines` not only strips lines empty lines and those that are prefixed with `#`, but also removes any trailing comments: the line `content # comment` is stripped to `content`.