### PR TITLE
files: add mkdir_p

### DIFF
--- a/files.ml
+++ b/files.ml
@@ -55,6 +55,18 @@ let () =
   iter_files "/etc" (fun s _ -> print_endline s)
 *)
 
+let mkdir_p ?(perm=0o755) path =
+  let rec aux path =
+    if Sys.file_exists path then begin
+      if not (Sys.is_directory path) then
+        Exn.fail "mkdir_p: %s exists but is not a directory" path
+    end else begin
+      aux (Filename.dirname path);
+      try Unix.mkdir path perm with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  aux path
+
 let save_as name ?(mode=0o644) f =
   (* not using make_temp_file cause same dir is needed for atomic rename *)
   let temp = Printf.sprintf "%s.save.%d.tmp" name (U.gettid ()) in

--- a/files.mli
+++ b/files.mli
@@ -16,6 +16,11 @@ val iter_files : string -> (string -> in_channel -> unit) -> unit
 val open_out_append_bin : string -> out_channel
 val open_out_append_text : string -> out_channel
 
+(** [mkdir_p ?perm path] creates directory [path] and all missing parent
+    directories. Similar to [mkdir -p]. Raises [Failure] if [path] exists
+    but is not a directory. Default [perm] is [0o755]. *)
+val mkdir_p : ?perm:Unix.file_perm -> string -> unit
+
 (** [save_as filename ?mode f] is similar to
     [Control.with_open_file_bin] except that writing is done to a
     temporary file that will be renamed to [filename] after [f] has


### PR DESCRIPTION
Add a `mkdir_p` function, similar to using `Fileutils`' `mkdir ~parent:true`, but without doing `umask`.