### PR TITLE
structured logging

### DIFF
--- a/daemon.ml
+++ b/daemon.ml
@@ -62,6 +62,12 @@ let unless_exit x = Lwt.pick [wait_exit (); x]
 let get_args () =
   [
     ("-loglevel", Arg.String Log.set_loglevels, " ([<facil|prefix*>=]debug|info|warn|error[,])+");
+    ("-logformat",
+      Arg.Symbol (["plain"; "default"; "logfmt"], (function
+        | "plain" | "default" -> Log.State.set_plaintext ()
+        | "logfmt" -> Log.State.set_logfmt ()
+        | s -> failwith (Printf.sprintf "unknown log format %S" s))),
+      " Log output format (default: plain)");
     ExtArg.may_str "logfile" logfile "<file> Log file";
     ExtArg.may_str "pidfile" pidfile "<file> PID file";
     "-runas",

--- a/httpev.ml
+++ b/httpev.ml
@@ -284,7 +284,7 @@ let finish ?(shutdown=true) c =
   | Ready req ->
     Hashtbl.remove c.server.reqs req.id;
     if c.server.config.debug then
-      log #info "finished %s" (show_request req)
+      log #info "finished" ~pairs:(pairs_of_request req)
 
 let write_f c (data,ack) ev fd _flags =
   let finish () = finish c; Ev.del ev in
@@ -324,7 +324,7 @@ let log_access_apache ch code size ?(background=false) req =
       (header_safe req "x-request-id")
       (if background then " (BG)" else "")
   with exn ->
-    log #warn ~exn "access log : %s" @@ show_request req
+    log #warn ~exn "access log" ~pairs:(pairs_of_request req)
 
 let log_status_apache ch status size req =
   match status with
@@ -498,10 +498,10 @@ let handle_request c body answer =
       | `Ok -> answer c.server req k
       end
     | _ ->
-      log #info "version %u.%u not supported from %s" (fst req.version) (snd req.version) (show_request req);
+      log #info "version %u.%u not supported" (fst req.version) (snd req.version) ~pairs:(pairs_of_request req);
       send_reply_async c Identity (`Version_not_supported,[],"HTTP/1.0 is supported")
   with exn ->
-    log #error ~exn "answer %s" @@ show_request req;
+    log #error ~exn "answer" ~pairs:(pairs_of_request req);
     match req.blocking with
     | None -> send_reply_async c Identity (`Not_found,[],"Not found")
     | Some _ -> Exn.suppress teardown c.fd
@@ -639,7 +639,7 @@ let check_hung_requests server =
   let now = Time.now () in
   server.reqs |> Hashtbl.iter begin fun _ req ->
     if req.recv -. now > Time.minutes 30 then
-      log #warn "request takes too much time to process : %s" (show_request req)
+      log #warn "request takes too much time to process" ~pairs:(pairs_of_request req)
   end
 
 let check_waiting_requests srv =
@@ -845,7 +845,7 @@ let answer_blocking ?(debug=false) srv req answer k =
     | Continue continue -> 200, Some continue
     | exn ->
       let saved_backtrace = Exn.get_backtrace () in
-      log #warn ~exn ~backtrace:debug ~saved_backtrace "answer forked %s" (show_request req);
+      log #warn ~exn ~backtrace:debug ~saved_backtrace "answer forked" ~pairs:(pairs_of_request req);
       -1, None
   in
   if srv.config.access_log_enabled then
@@ -861,7 +861,7 @@ let nr_rejected = stats#count "rejected"
 let answer_forked ?debug srv req answer k =
   let do_fork () =
     match check_req req with
-    | `Error err -> Exn.fail "pre fork %s : %s" (show_request req) (Unix.error_message err)
+    | `Error err -> Exn.fail "pre fork : %s" (show_request req) (Unix.error_message err)
     | `Ok ->
     begin match Nix.fork () with
     | `Child ->
@@ -873,7 +873,7 @@ let answer_forked ?debug srv req answer k =
       end;
       U.sys_exit 0
     | `Forked pid ->
-      log #info "forked %d : %s" pid (show_request req);
+      log #info "forked %d" pid ~pairs:(pairs_of_request req);
       k (`No_reply,[],""); (* close socket in parent immediately *)
       Hashtbl.add srv.h_childs pid ()
     end
@@ -883,7 +883,7 @@ let answer_forked ?debug srv req answer k =
       do_fork ()
     with
       exn ->
-        log #warn ~exn "answer fork failed %s" (show_request req);
+        log #warn ~exn "answer fork failed" ~pairs:(pairs_of_request req);
         k (`Internal_server_error,[],"")
   in
   if Hashtbl.length srv.h_childs < srv.config.max_data_childs then
@@ -899,7 +899,7 @@ let answer_forked ?debug srv req answer k =
   else
   begin
     incr nr_rejected;
-    log #info "rejecting, overloaded : %s" (show_request req);
+    log #info "rejecting, overloaded" ~pairs:(pairs_of_request req);
     k (`Service_unavailable, ["Content-Type", "text/plain"], "overloaded")
   end
 
@@ -989,11 +989,11 @@ let handle_request_lwt c req answer =
       try%lwt
         answer c.server req
       with exn ->
-        log #error ~exn "answer %s" @@ show_request req;
+        log #error ~exn "answer" ~pairs:(pairs_of_request req);
         return (`Not_found,[],"Not found")
     end
   | _ ->
-    log #info "version %u.%u not supported from %s" (fst req.version) (snd req.version) (show_request req);
+    log #info "version %u.%u not supported" (fst req.version) (snd req.version) ~pairs:(pairs_of_request req);
     return (`Version_not_supported,[],"HTTP/1.0 is supported")
 
 let read_buf ic buf =
@@ -1163,7 +1163,7 @@ let rest ~show_exn req answer =
   | Arg.Bad s -> bad_request @@ sprintf "bad parameter %s in %s" s req.url
   | exn ->
     let ref = random_ref () in
-    log#warn ~exn "failed ref:%Ld %s" ref (show_request req);
+    log#warn ~exn "failed ref:%Ld" ref ~pairs:(pairs_of_request req);
     if show_exn then
       internal_error @@ sprintf "internal error ref:%Ld : %s" ref (match exn with Failure s -> s | _ -> Exn.str exn)
     else

--- a/httpev.ml
+++ b/httpev.ml
@@ -275,6 +275,13 @@ let teardown fd =
   Exn.suppress (Unix.shutdown fd) Unix.SHUTDOWN_ALL;
   Unix.close fd
 
+let log_req ?exn ?backtrace ?saved_backtrace level req fmt =
+  ksprintf (fun msg ->
+    match Log.State.get_cur_format () with
+    | `Plain, _ -> log #put level ?exn ?backtrace ?saved_backtrace "%s : %s" msg (show_request req)
+    | `Logfmt, _ -> log #put level ?exn ?backtrace ?saved_backtrace "%s" msg ~pairs:(pairs_of_request req)
+  ) fmt
+
 let finish ?(shutdown=true) c =
   decr_active c.server;
   Hashtbl.remove c.server.clients c.req_id;
@@ -284,7 +291,7 @@ let finish ?(shutdown=true) c =
   | Ready req ->
     Hashtbl.remove c.server.reqs req.id;
     if c.server.config.debug then
-      log #info "finished" ~pairs:(pairs_of_request req)
+      log_req `Info req "finished"
 
 let write_f c (data,ack) ev fd _flags =
   let finish () = finish c; Ev.del ev in
@@ -324,7 +331,7 @@ let log_access_apache ch code size ?(background=false) req =
       (header_safe req "x-request-id")
       (if background then " (BG)" else "")
   with exn ->
-    log #warn ~exn "access log" ~pairs:(pairs_of_request req)
+    log_req ~exn `Warn req "access log"
 
 let log_status_apache ch status size req =
   match status with
@@ -498,10 +505,10 @@ let handle_request c body answer =
       | `Ok -> answer c.server req k
       end
     | _ ->
-      log #info "version %u.%u not supported" (fst req.version) (snd req.version) ~pairs:(pairs_of_request req);
+      log_req `Info req "version %u.%u not supported" (fst req.version) (snd req.version);
       send_reply_async c Identity (`Version_not_supported,[],"HTTP/1.0 is supported")
   with exn ->
-    log #error ~exn "answer" ~pairs:(pairs_of_request req);
+    log_req ~exn `Error req "answer";
     match req.blocking with
     | None -> send_reply_async c Identity (`Not_found,[],"Not found")
     | Some _ -> Exn.suppress teardown c.fd
@@ -639,7 +646,7 @@ let check_hung_requests server =
   let now = Time.now () in
   server.reqs |> Hashtbl.iter begin fun _ req ->
     if req.recv -. now > Time.minutes 30 then
-      log #warn "request takes too much time to process" ~pairs:(pairs_of_request req)
+      log_req `Warn req "request takes too much time to process"
   end
 
 let check_waiting_requests srv =
@@ -845,7 +852,7 @@ let answer_blocking ?(debug=false) srv req answer k =
     | Continue continue -> 200, Some continue
     | exn ->
       let saved_backtrace = Exn.get_backtrace () in
-      log #warn ~exn ~backtrace:debug ~saved_backtrace "answer forked" ~pairs:(pairs_of_request req);
+      log_req ~exn ~backtrace:debug ~saved_backtrace `Warn req "answer forked";
       -1, None
   in
   if srv.config.access_log_enabled then
@@ -861,7 +868,7 @@ let nr_rejected = stats#count "rejected"
 let answer_forked ?debug srv req answer k =
   let do_fork () =
     match check_req req with
-    | `Error err -> Exn.fail "pre fork : %s" (show_request req) (Unix.error_message err)
+    | `Error err -> Exn.fail "pre fork %s : %s" (show_request req) (Unix.error_message err)
     | `Ok ->
     begin match Nix.fork () with
     | `Child ->
@@ -873,7 +880,7 @@ let answer_forked ?debug srv req answer k =
       end;
       U.sys_exit 0
     | `Forked pid ->
-      log #info "forked %d" pid ~pairs:(pairs_of_request req);
+      log_req `Info req "forked %d" pid;
       k (`No_reply,[],""); (* close socket in parent immediately *)
       Hashtbl.add srv.h_childs pid ()
     end
@@ -883,7 +890,7 @@ let answer_forked ?debug srv req answer k =
       do_fork ()
     with
       exn ->
-        log #warn ~exn "answer fork failed" ~pairs:(pairs_of_request req);
+        log_req ~exn `Warn req "answer fork failed";
         k (`Internal_server_error,[],"")
   in
   if Hashtbl.length srv.h_childs < srv.config.max_data_childs then
@@ -899,7 +906,7 @@ let answer_forked ?debug srv req answer k =
   else
   begin
     incr nr_rejected;
-    log #info "rejecting, overloaded" ~pairs:(pairs_of_request req);
+    log_req `Info req "rejecting, overloaded";
     k (`Service_unavailable, ["Content-Type", "text/plain"], "overloaded")
   end
 
@@ -989,11 +996,11 @@ let handle_request_lwt c req answer =
       try%lwt
         answer c.server req
       with exn ->
-        log #error ~exn "answer" ~pairs:(pairs_of_request req);
+        log_req ~exn `Error req "answer";
         return (`Not_found,[],"Not found")
     end
   | _ ->
-    log #info "version %u.%u not supported" (fst req.version) (snd req.version) ~pairs:(pairs_of_request req);
+    log_req `Info req "version %u.%u not supported" (fst req.version) (snd req.version);
     return (`Version_not_supported,[],"HTTP/1.0 is supported")
 
 let read_buf ic buf =
@@ -1163,7 +1170,7 @@ let rest ~show_exn req answer =
   | Arg.Bad s -> bad_request @@ sprintf "bad parameter %s in %s" s req.url
   | exn ->
     let ref = random_ref () in
-    log#warn ~exn "failed ref:%Ld" ref ~pairs:(pairs_of_request req);
+    log_req ~exn `Warn req "failed ref:%Ld" ref;
     if show_exn then
       internal_error @@ sprintf "internal error ref:%Ld : %s" ref (match exn with Failure s -> s | _ -> Exn.str exn)
     else

--- a/httpev.ml
+++ b/httpev.ml
@@ -275,13 +275,6 @@ let teardown fd =
   Exn.suppress (Unix.shutdown fd) Unix.SHUTDOWN_ALL;
   Unix.close fd
 
-let log_req ?exn ?backtrace ?saved_backtrace level req fmt =
-  ksprintf (fun msg ->
-    match Log.State.get_cur_format () with
-    | `Plain, _ -> log #put level ?exn ?backtrace ?saved_backtrace "%s : %s" msg (show_request req)
-    | `Logfmt, _ -> log #put level ?exn ?backtrace ?saved_backtrace "%s" msg ~pairs:(pairs_of_request req)
-  ) fmt
-
 let finish ?(shutdown=true) c =
   decr_active c.server;
   Hashtbl.remove c.server.clients c.req_id;
@@ -291,7 +284,7 @@ let finish ?(shutdown=true) c =
   | Ready req ->
     Hashtbl.remove c.server.reqs req.id;
     if c.server.config.debug then
-      log_req `Info req "finished"
+      log #info "finished %s" (show_request req) ~structured_pairs:(pairs_of_request req)
 
 let write_f c (data,ack) ev fd _flags =
   let finish () = finish c; Ev.del ev in
@@ -331,7 +324,7 @@ let log_access_apache ch code size ?(background=false) req =
       (header_safe req "x-request-id")
       (if background then " (BG)" else "")
   with exn ->
-    log_req ~exn `Warn req "access log"
+    log #warn ~exn "access log : %s" (show_request req) ~structured_pairs:(pairs_of_request req)
 
 let log_status_apache ch status size req =
   match status with
@@ -505,10 +498,10 @@ let handle_request c body answer =
       | `Ok -> answer c.server req k
       end
     | _ ->
-      log_req `Info req "version %u.%u not supported" (fst req.version) (snd req.version);
+      log #info "version %u.%u not supported from %s" (fst req.version) (snd req.version) (show_request req) ~structured_pairs:(pairs_of_request req);
       send_reply_async c Identity (`Version_not_supported,[],"HTTP/1.0 is supported")
   with exn ->
-    log_req ~exn `Error req "answer";
+    log #error ~exn "answer %s" (show_request req) ~structured_pairs:(pairs_of_request req);
     match req.blocking with
     | None -> send_reply_async c Identity (`Not_found,[],"Not found")
     | Some _ -> Exn.suppress teardown c.fd
@@ -646,7 +639,7 @@ let check_hung_requests server =
   let now = Time.now () in
   server.reqs |> Hashtbl.iter begin fun _ req ->
     if req.recv -. now > Time.minutes 30 then
-      log_req `Warn req "request takes too much time to process"
+      log #warn "request takes too much time to process : %s" (show_request req) ~structured_pairs:(pairs_of_request req)
   end
 
 let check_waiting_requests srv =
@@ -852,7 +845,7 @@ let answer_blocking ?(debug=false) srv req answer k =
     | Continue continue -> 200, Some continue
     | exn ->
       let saved_backtrace = Exn.get_backtrace () in
-      log_req ~exn ~backtrace:debug ~saved_backtrace `Warn req "answer forked";
+      log #warn ~exn ~backtrace:debug ~saved_backtrace "answer forked %s" (show_request req) ~structured_pairs:(pairs_of_request req);
       -1, None
   in
   if srv.config.access_log_enabled then
@@ -880,7 +873,7 @@ let answer_forked ?debug srv req answer k =
       end;
       U.sys_exit 0
     | `Forked pid ->
-      log_req `Info req "forked %d" pid;
+      log #info "forked %d : %s" pid (show_request req) ~structured_pairs:(pairs_of_request req);
       k (`No_reply,[],""); (* close socket in parent immediately *)
       Hashtbl.add srv.h_childs pid ()
     end
@@ -890,7 +883,7 @@ let answer_forked ?debug srv req answer k =
       do_fork ()
     with
       exn ->
-        log_req ~exn `Warn req "answer fork failed";
+        log #warn ~exn "answer fork failed %s" (show_request req) ~structured_pairs:(pairs_of_request req);
         k (`Internal_server_error,[],"")
   in
   if Hashtbl.length srv.h_childs < srv.config.max_data_childs then
@@ -906,7 +899,7 @@ let answer_forked ?debug srv req answer k =
   else
   begin
     incr nr_rejected;
-    log_req `Info req "rejecting, overloaded";
+    log #info "rejecting, overloaded : %s" (show_request req) ~structured_pairs:(pairs_of_request req);
     k (`Service_unavailable, ["Content-Type", "text/plain"], "overloaded")
   end
 
@@ -996,11 +989,11 @@ let handle_request_lwt c req answer =
       try%lwt
         answer c.server req
       with exn ->
-        log_req ~exn `Error req "answer";
+        log #error ~exn "answer %s" (show_request req) ~structured_pairs:(pairs_of_request req);
         return (`Not_found,[],"Not found")
     end
   | _ ->
-    log_req `Info req "version %u.%u not supported" (fst req.version) (snd req.version);
+    log #info "version %u.%u not supported from %s" (fst req.version) (snd req.version) (show_request req) ~structured_pairs:(pairs_of_request req);
     return (`Version_not_supported,[],"HTTP/1.0 is supported")
 
 let read_buf ic buf =
@@ -1170,7 +1163,7 @@ let rest ~show_exn req answer =
   | Arg.Bad s -> bad_request @@ sprintf "bad parameter %s in %s" s req.url
   | exn ->
     let ref = random_ref () in
-    log_req ~exn `Warn req "failed ref:%Ld" ref;
+    log#warn ~exn "failed ref:%Ld %s" ref (show_request req) ~structured_pairs:(pairs_of_request req);
     if show_exn then
       internal_error @@ sprintf "internal error ref:%Ld : %s" ref (match exn with Failure s -> s | _ -> Exn.str exn)
     else

--- a/httpev_common.ml
+++ b/httpev_common.ml
@@ -107,14 +107,14 @@ let show_request req =
     (header_safe req "x-request-id")
 
 let pairs_of_request req : Logger.Pairs.t =
-  [ "req.id", string_of_int req.id;
-    "client.addr", show_client_addr req;
-    "duration", sprintf "%.4f" (Time.get () -. req.conn);
-    "duration.recv", sprintf "%.4f" (req.recv -. req.conn);
-    "header.host", header_safe req "host";
+  [ "req_id", string_of_int req.id;
+    "client_addr", show_client_addr req;
+    "http_duration", sprintf "%.4f" (Time.get () -. req.conn);
+    "http_recv_duration", sprintf "%.4f" (req.recv -. req.conn);
+    "http_host", header_safe req "host";
     "url", req.url;
-    "header.user-agent", header_safe req "user-agent";
-    "header.req-id", header_safe req "x-request-id"
+    "http_user_agent", header_safe req "user-agent";
+    "http_req_id", header_safe req "x-request-id"
   ]
 
 let status_code : reply_status -> int = function

--- a/httpev_common.ml
+++ b/httpev_common.ml
@@ -106,6 +106,17 @@ let show_request req =
     (header_safe req "user-agent")
     (header_safe req "x-request-id")
 
+let pairs_of_request req : Logger.Pairs.t =
+  [ "req.id", string_of_int req.id;
+    "client.addr", show_client_addr req;
+    "duration", sprintf "%.4f" (Time.get () -. req.conn);
+    "duration.recv", sprintf "%.4f" (req.recv -. req.conn);
+    "header.host", header_safe req "host";
+    "url", req.url;
+    "header.user-agent", header_safe req "user-agent";
+    "header.req-id", header_safe req "x-request-id"
+  ]
+
 let status_code : reply_status -> int = function
   | `Ok -> 200
   | `Created -> 201

--- a/log.ml
+++ b/log.ml
@@ -91,16 +91,25 @@ module State = struct
       pairs_str
 
   let format_logfmt level facil ts pairs msg =
-    let pairs = [
-      "level", Logger.string_level level;
-      "facil", facil;
-      "time", Time.to_string ~gmt:!utc_timezone ~ms:true ts;
-      "msg", msg;
-    ] @ pairs in
+    let pairs = ("msg", msg) :: pairs in
+    let pid = Unix.getpid () in
+    let tid = U.gettid () in
+    let pairs =
+      if pid = tid then ("pid", string_of_int pid) :: pairs
+      else ("pid", string_of_int pid) :: ("tid", string_of_int tid) :: pairs
+    in
+    let pairs =
+      ("time", Time.to_string ~gmt:!utc_timezone ~ms:true ts) ::
+      ("level", Logger.string_level level) ::
+      ("facil", facil.Logger.name) ::
+      pairs
+    in
     Logfmt.to_string pairs
 
   let cur_format = Atomic.make format_simple_full
   let set_cur_format f = Atomic.set cur_format f
+  let set_plaintext () = set_cur_format format_simple_full
+  let set_logfmt () = set_cur_format format_logfmt
 
   let format level facil ts pairs msg =
     (Atomic.get cur_format) level facil ts pairs msg

--- a/log.ml
+++ b/log.ml
@@ -104,7 +104,10 @@ module State = struct
       ("facil", facil.Logger.name) ::
       pairs
     in
-    Logfmt.to_string pairs
+    let buf = Buffer.create 32 in
+    Logfmt.add_to_buffer buf pairs;
+    Buffer.add_char buf '\n';
+    Buffer.contents buf
 
   let cur_format = Atomic.make format_simple_full
   let set_cur_format f = Atomic.set cur_format f

--- a/log.ml
+++ b/log.ml
@@ -215,7 +215,7 @@ class logger facil =
     List.iter (fun line -> output_line facil ts pairs ("    " ^ line)) bt
   in
   fun ?exn ?(lines=true) ?(backtrace=false) ?saved_backtrace ?(ts=Unix.gettimeofday()) ?(structured_pairs=[]) ?(pairs=[]) s ->
-    let pairs = if structured_pairs!=[] && State.is_structured_format () then List.rev_append structured_pairs pairs else pairs in
+    let pairs = if State.is_structured_format () then List.rev_append structured_pairs pairs else pairs in
     try
       match exn with
       | None -> output lines facil ts pairs s

--- a/log.ml
+++ b/log.ml
@@ -113,6 +113,7 @@ module State = struct
     let set_cur_format f = Atomic.set cur_format f
   end
   let get_cur_format () = Atomic.get cur_format
+  let is_structured_format () = match get_cur_format () with `Plain, _ -> false | `Logfmt, _ -> true
   let set_plaintext () = set_cur_format (`Plain, format_simple_full)
   let set_logfmt () = set_cur_format (`Logfmt, format_logfmt)
 
@@ -188,11 +189,15 @@ let read_env_config = State.read_env_config
 (**
   param [lines]: whether to split multiline message as separate log lines (default [true])
 
-  param [backtrace]: whether to show backtrace if [exn] is given (default is [false])
+  param [backtrace]: whethgter to show backtrace if [exn] is given (default is [false])
 
   param [saved_backtrace]: supply backtrace to show instead of using [Printexc.get_backtrace]
+
+  param [pairs] key/value pairs to add to the line, unconditionally
+
+  param [structured_pairs] key/value pairs to use for structured log formats only. Plain logging will discard.
 *)
-type 'a pr = ?exn:exn -> ?lines:bool -> ?backtrace:bool -> ?saved_backtrace:string list -> ?ts:Time.t -> ?pairs:Logger.Pairs.t -> ('a, unit, string, unit) format4 -> 'a
+type 'a pr = ?exn:exn -> ?lines:bool -> ?backtrace:bool -> ?saved_backtrace:string list -> ?ts:Time.t -> ?structured_pairs:Logger.Pairs.t -> ?pairs:Logger.Pairs.t -> ('a, unit, string, unit) format4 -> 'a
 
 class logger facil =
   let make_s (output_line:Logger.facil -> Time.t -> Logger.Pairs.t -> string -> unit) =
@@ -209,7 +214,8 @@ class logger facil =
     output lines facil ts pairs (s ^ " : exn " ^ Exn.str exn ^ (if bt = [] then " (no backtrace)" else ""));
     List.iter (fun line -> output_line facil ts pairs ("    " ^ line)) bt
   in
-  fun ?exn ?(lines=true) ?(backtrace=false) ?saved_backtrace ?(ts=Unix.gettimeofday()) ?(pairs=[]) s ->
+  fun ?exn ?(lines=true) ?(backtrace=false) ?saved_backtrace ?(ts=Unix.gettimeofday()) ?(structured_pairs=[]) ?(pairs=[]) s ->
+    let pairs = if structured_pairs!=[] && State.is_structured_format () then List.rev_append structured_pairs pairs else pairs in
     try
       match exn with
       | None -> output lines facil ts pairs s
@@ -223,8 +229,8 @@ class logger facil =
     with exn ->
       output_line facil ts pairs (sprintf "LOG FAILED : %S with message %S" (Exn.str exn) s)
 in
-let make : _ -> _ pr = fun output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?pairs fmt ->
-  ksprintf (fun s -> output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?pairs s) fmt
+let make : _ -> _ pr = fun output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?structured_pairs ?pairs fmt ->
+    ksprintf (fun s -> output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?structured_pairs ?pairs s) fmt
 in
 let debug_s = make_s debug_s in
 let warn_s = make_s warn_s in

--- a/log.ml
+++ b/log.ml
@@ -77,30 +77,50 @@ module State = struct
   let output_ch ch =
     fun str -> try output_string ch str; flush ch with _ -> () (* logging never fails, most probably ENOSPC *)
 
-  let format_simple level facil msg =
+  let format_simple_full level facil ts pairs msg =
     let pid = Unix.getpid () in
     let tid = U.gettid () in
     let pinfo = if pid = tid then sprintf "%5u:" pid else sprintf "%5u:%u" pid tid in
-    sprintf "[%s] %s [%s:%s] %s\n"
-      (Time.to_string ~gmt:!utc_timezone ~ms:true (Unix.gettimeofday ()))
+    let pairs_str = match pairs with [] -> "" | _ -> " " ^ Logfmt.to_string pairs in
+    sprintf "[%s] %s [%s:%s] %s%s\n"
+      (Time.to_string ~gmt:!utc_timezone ~ms:true ts)
       pinfo
       facil.Logger.name
       (Logger.string_level level)
       msg
+      pairs_str
+
+  let format_logfmt level facil ts pairs msg =
+    let pairs = [
+      "level", Logger.string_level level;
+      "facil", facil;
+      "time", Time.to_string ~gmt:!utc_timezone ~ms:true ts;
+      "msg", msg;
+    ] @ pairs in
+    Logfmt.to_string pairs
+
+  let cur_format = Atomic.make format_simple_full
+  let set_cur_format f = Atomic.set cur_format f
+
+  let format level facil ts pairs msg =
+    (Atomic.get cur_format) level facil ts pairs msg
+
+  let format_simple level facil msg =
+    format level facil (Unix.gettimeofday()) [] msg
 
   let log_ch = stderr
   let () = assert (Unix.descr_of_out_channel stderr = Unix.stderr)
   let base_name = ref ""
-
   let hook = ref (fun _ _ _ -> ())
+  let output_simple level facil s = !hook level facil s; output_ch log_ch s
 
-  module Put = Logger.PutSimple(
-  struct
-    let format = format_simple
-    let output = fun level facil s -> let () = !hook level facil s in output_ch log_ch s
-  end)
+  let put = Logger.put_simple {
+    format;
+    output = output_simple;
+  }
 
-  module M = Logger.Make(Put)
+  (** Main logger, writes into [put] *)
+  let logger = Logger.make put
 
   let self = "lib"
 
@@ -117,11 +137,23 @@ module State = struct
         (fun () -> Unix.dup2 (Unix.descr_of_out_channel ch) Unix.stderr)
         ()
     with
-      e -> M.warn (facility self) "reopen_log_ch(%s) failed : %s" file (Printexc.to_string e)
+      e ->
+        let now = (Unix.gettimeofday ()) in
+        logger.warn (facility self) now [] "reopen_log_ch(%s) failed : %s" file (Printexc.to_string e)
 
 end
 
-include State.M
+let debug_s = State.logger.debug_s
+let info_s = State.logger.info_s
+let warn_s = State.logger.warn_s
+let error_s = State.logger.error_s
+let critical_s = State.logger.critical_s
+let put_s = State.logger.put_s
+let debug = State.logger.debug
+let info = State.logger.info
+let warn = State.logger.warn
+let error = State.logger.error
+let critical = State.logger.critical
 
 let facility = State.facility
 let set_filter = State.set_filter
@@ -146,39 +178,39 @@ let read_env_config = State.read_env_config
 
   param [saved_backtrace]: supply backtrace to show instead of using [Printexc.get_backtrace]
 *)
-type 'a pr = ?exn:exn -> ?lines:bool -> ?backtrace:bool -> ?saved_backtrace:string list -> ('a, unit, string, unit) format4 -> 'a
+type 'a pr = ?exn:exn -> ?lines:bool -> ?backtrace:bool -> ?saved_backtrace:string list -> ?ts:Time.t -> ?pairs:Logger.Pairs.t -> ('a, unit, string, unit) format4 -> 'a
 
 class logger facil =
-let make_s output_line =
+  let make_s (output_line:Logger.facil -> Time.t -> Logger.Pairs.t -> string -> unit) =
   let output = function
   | true ->
-      fun facil s ->
+      fun facil ts pairs s ->
         if String.contains s '\n' then
-          List.iter (output_line facil) @@ String.nsplit s "\n"
+          List.iter (output_line facil ts pairs) @@ String.nsplit s "\n"
         else
-          output_line facil s
+          output_line facil ts pairs s
   | false -> output_line
   in
-  let print_bt lines exn bt s =
-    output lines facil (s ^ " : exn " ^ Exn.str exn ^ (if bt = [] then " (no backtrace)" else ""));
-    List.iter (fun line -> output_line facil ("    " ^ line)) bt
+  let print_bt lines exn bt ts pairs s =
+    output lines facil ts pairs (s ^ " : exn " ^ Exn.str exn ^ (if bt = [] then " (no backtrace)" else ""));
+    List.iter (fun line -> output_line facil ts pairs ("    " ^ line)) bt
   in
-  fun ?exn ?(lines=true) ?(backtrace=false) ?saved_backtrace s ->
+  fun ?exn ?(lines=true) ?(backtrace=false) ?saved_backtrace ?(ts=Unix.gettimeofday()) ?(pairs=[]) s ->
     try
       match exn with
-      | None -> output lines facil s
+      | None -> output lines facil ts pairs s
       | Some exn ->
       match saved_backtrace with
-      | Some bt -> print_bt lines exn bt s
+      | Some bt -> print_bt lines exn bt ts pairs s
       | None ->
       match backtrace with
-      | true -> print_bt lines exn (Exn.get_backtrace ()) s
-      | false -> output lines facil (s ^ " : exn " ^ Exn.str exn)
+      | true -> print_bt lines exn (Exn.get_backtrace ()) ts pairs s
+      | false -> output lines facil ts pairs (s ^ " : exn " ^ Exn.str exn)
     with exn ->
-      output_line facil (sprintf "LOG FAILED : %S with message %S" (Exn.str exn) s)
+      output_line facil ts pairs (sprintf "LOG FAILED : %S with message %S" (Exn.str exn) s)
 in
-let make output ?exn ?lines ?backtrace ?saved_backtrace fmt =
-  ksprintf (fun s -> output ?exn ?lines ?backtrace ?saved_backtrace s) fmt
+let make : _ -> _ pr = fun output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?pairs fmt ->
+  ksprintf (fun s -> output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?pairs s) fmt
 in
 let debug_s = make_s debug_s in
 let warn_s = make_s warn_s in

--- a/log.ml
+++ b/log.ml
@@ -189,7 +189,7 @@ let read_env_config = State.read_env_config
 (**
   param [lines]: whether to split multiline message as separate log lines (default [true])
 
-  param [backtrace]: whethgter to show backtrace if [exn] is given (default is [false])
+  param [backtrace]: whether to show backtrace if [exn] is given (default is [false])
 
   param [saved_backtrace]: supply backtrace to show instead of using [Printexc.get_backtrace]
 

--- a/log.ml
+++ b/log.ml
@@ -129,13 +129,11 @@ module State = struct
   let hook = ref (fun _ _ _ -> ())
   let output_simple level facil s = !hook level facil s; output_ch log_ch s
 
-  let put = Logger.put_simple {
+  (** Main logger *)
+  let logger = Logger.put_simple {
     format;
     output = output_simple;
   }
-
-  (** Main logger, writes into [put] *)
-  let logger = Logger.make put
 
   let self = "lib"
 
@@ -154,21 +152,9 @@ module State = struct
     with
       e ->
         let now = (Unix.gettimeofday ()) in
-        logger.warn (facility self) now [] "reopen_log_ch(%s) failed : %s" file (Printexc.to_string e)
+        logger.put `Warn (facility self) now [] (sprintf "reopen_log_ch(%s) failed : %s" file (Printexc.to_string e))
 
 end
-
-let debug_s = State.logger.debug_s
-let info_s = State.logger.info_s
-let warn_s = State.logger.warn_s
-let error_s = State.logger.error_s
-let critical_s = State.logger.critical_s
-let put_s = State.logger.put_s
-let debug = State.logger.debug
-let info = State.logger.info
-let warn = State.logger.warn
-let error = State.logger.error
-let critical = State.logger.critical
 
 let facility = State.facility
 let set_filter = State.set_filter
@@ -232,12 +218,12 @@ in
 let make : _ -> _ pr = fun output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?structured_pairs ?pairs fmt ->
     ksprintf (fun s -> output ?exn ?lines ?backtrace ?saved_backtrace ?ts ?structured_pairs ?pairs s) fmt
 in
-let debug_s = make_s debug_s in
-let warn_s = make_s warn_s in
-let info_s = make_s info_s in
-let error_s = make_s error_s in
-let critical_s = make_s critical_s in
-let put_s level = make_s (put_s level) in
+let debug_s = make_s (State.logger.put `Debug) in
+let warn_s = make_s (State.logger.put `Warn) in
+let info_s = make_s (State.logger.put `Info) in
+let error_s = make_s (State.logger.put `Error) in
+let critical_s = make_s (State.logger.put `Critical) in
+let put_s level = make_s (State.logger.put level) in
 object
 method debug_s = debug_s
 method warn_s = warn_s

--- a/log.ml
+++ b/log.ml
@@ -40,7 +40,6 @@ open Prelude
 
 (** Global logger state *)
 module State = struct
-
   let all = Hashtbl.create 10
   let default_level = ref (`Info : Logger.level)
 
@@ -109,13 +108,16 @@ module State = struct
     Buffer.add_char buf '\n';
     Buffer.contents buf
 
-  let cur_format = Atomic.make format_simple_full
-  let set_cur_format f = Atomic.set cur_format f
-  let set_plaintext () = set_cur_format format_simple_full
-  let set_logfmt () = set_cur_format format_logfmt
+  open struct
+    let cur_format: ([`Plain|`Logfmt]*_) Atomic.t = Atomic.make (`Plain, format_simple_full)
+    let set_cur_format f = Atomic.set cur_format f
+  end
+  let get_cur_format () = Atomic.get cur_format
+  let set_plaintext () = set_cur_format (`Plain, format_simple_full)
+  let set_logfmt () = set_cur_format (`Logfmt, format_logfmt)
 
   let format level facil ts pairs msg =
-    (Atomic.get cur_format) level facil ts pairs msg
+    (snd (Atomic.get cur_format)) level facil ts pairs msg
 
   let format_simple level facil msg =
     format level facil (Unix.gettimeofday()) [] msg

--- a/logfmt.ml
+++ b/logfmt.ml
@@ -1,0 +1,37 @@
+
+let[@inline] needs_escape c = Char.code c < 0x20 || Char.code c >= 0x7f
+
+type cat = Safe | Has_space | Needs_escape
+
+let categorize s : cat =
+  let space = ref false in
+
+  try
+    for i=0 to String.length s-1 do
+      let c = String.unsafe_get s i in
+      if needs_escape c then raise_notrace Exit;
+      if c = ' ' then space := true
+    done;
+    if !space then Has_space else Safe
+  with Exit -> Needs_escape
+
+let add_pair buf k v =
+  Buffer.add_string buf k;
+  Buffer.add_char buf '=';
+  match categorize v with
+  | Safe -> Buffer.add_string buf v
+  | Has_space -> Printf.bprintf buf {|"%s"|} v
+  | Needs_escape -> Printf.bprintf buf "%S" v
+
+let rec add_to_buffer buf (pairs:Logger.Pairs.t) : unit =
+  match pairs with
+  | [] -> ()
+  | [k,v] -> add_pair buf k v
+  | (k,v) :: pairs -> add_pair buf k v; Buffer.add_char buf ' '; add_to_buffer buf pairs
+
+let to_string pairs = match pairs with
+  | [] -> ""
+  | _ ->
+    let buf = Buffer.create 32 in
+    add_to_buffer buf pairs;
+    Buffer.contents buf

--- a/logfmt.ml
+++ b/logfmt.ml
@@ -1,18 +1,22 @@
 
-let[@inline] needs_escape c = Char.code c < 0x20 || Char.code c >= 0x7f
+let[@inline] needs_escape c =
+  Char.code c < 0x20 || c = '"' || c = '\\'
+
+let[@inline] needs_quotes c =
+  c = ' ' || Char.code c >= 0x80
 
 type cat = Safe | Has_space | Needs_escape
 
 let categorize s : cat =
-  let space = ref false in
+  let quote = ref false in
 
   try
     for i=0 to String.length s-1 do
       let c = String.unsafe_get s i in
       if needs_escape c then raise_notrace Exit;
-      if c = ' ' then space := true
+      if needs_quotes c then quote := true
     done;
-    if !space then Has_space else Safe
+    if !quote then Has_space else Safe
   with Exit -> Needs_escape
 
 let add_pair buf k v =

--- a/logfmt.mli
+++ b/logfmt.mli
@@ -1,0 +1,3 @@
+
+val add_to_buffer : Buffer.t -> Logger.Pairs.t -> unit
+val to_string : Logger.Pairs.t -> string

--- a/logger.ml
+++ b/logger.ml
@@ -47,17 +47,18 @@ type target = {
   output : level -> facil -> string -> unit;
 }
 
-type put = {
+(** A logger *)
+type t = {
   put : level -> facil -> Time.t -> Pairs.t -> string -> unit
 } [@@unboxed]
 
-let put_simple (t:target) : put = {
+let put_simple (t:target) : t = {
   put = fun level facil ts pairs str ->
     if allowed facil level then
       t.output level facil (t.format level facil ts pairs str)
 }
 
-let put_limited (t:target) : put =
+let put_limited (t:target) : t =
   let last = ref (`Debug,"") in
   let n = ref 0 in
 
@@ -81,32 +82,3 @@ let put_limited (t:target) : put =
         t.output level facil (t.format level facil ts pairs str);
       end
   in { put }
-
-(** A logger *)
-type t = {
-  debug_s: facil -> Time.t -> Pairs.t -> string -> unit;
-  info_s: facil -> Time.t -> Pairs.t -> string -> unit;
-  warn_s: facil -> Time.t -> Pairs.t -> string -> unit;
-  error_s: facil -> Time.t -> Pairs.t -> string -> unit;
-  critical_s: facil -> Time.t -> Pairs.t -> string -> unit;
-  put_s: level -> facil -> Time.t -> Pairs.t -> string -> unit;
-  debug: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
-  info: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
-  warn: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
-  error: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
-  critical: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
-}
-
-let make (t:put) : t =
-  let debug_s = t.put `Debug in
-  let info_s = t.put `Info in
-  let warn_s = t.put `Warn in
-  let error_s = t.put `Error in
-  let critical_s = t.put `Critical in
-  let put_s = t.put in
-  let debug f ts pairs fmt = ksprintf (debug_s f ts pairs) fmt in
-  let info f ts pairs fmt = ksprintf (info_s f ts pairs) fmt in
-  let warn f ts pairs fmt = ksprintf (warn_s f ts pairs) fmt in
-  let error f ts pairs fmt = ksprintf (error_s f ts pairs) fmt in
-  let critical f ts pairs fmt = ksprintf (critical_s f ts pairs) fmt in
-  { debug_s; info_s; warn_s; error_s; critical_s; put_s; debug; info; warn; error; critical }

--- a/logger.ml
+++ b/logger.ml
@@ -37,33 +37,32 @@ let level = function
   | "nothing" -> `Nothing
   | s -> Exn.fail "unrecognized level %s" s
 
-module type Target =
-sig
-  val format : level -> facil -> string -> string
-  val output : level -> facil -> string -> unit
+module Pairs = struct
+  type pair = string*string
+  type t = pair list
 end
 
-module type Put = sig
-val put : level -> facil -> string -> unit
-end
+type target = {
+  format : level -> facil -> Time.t -> Pairs.t -> string -> string;
+  output : level -> facil -> string -> unit;
+}
 
-module PutSimple(T : Target) : Put =
-struct
+type put = {
+  put : level -> facil -> Time.t -> Pairs.t -> string -> unit
+} [@@unboxed]
 
-  let put level facil str =
+let put_simple (t:target) : put = {
+  put = fun level facil ts pairs str ->
     if allowed facil level then
-      T.output level facil (T.format level facil str)
+      t.output level facil (t.format level facil ts pairs str)
+}
 
-end
+let put_limited (t:target) : put =
+  let last = ref (`Debug,"") in
+  let n = ref 0 in
 
-module PutLimited(T : Target) : Put =
-struct
-
-  let last = ref (`Debug,"")
-  let n = ref 0
-
-  (** FIXME not thread safe *)
-  let put level facil str =
+  (* FIXME not thread safe *)
+  let put level facil ts pairs str =
     match allowed facil level with
     | false -> ()
     | true ->
@@ -74,29 +73,40 @@ struct
       begin
         if !n <> 0 then
         begin
-         T.output level facil (sprintf
+         t.output level facil (sprintf
           "last message repeated %u times, suppressed\n" !n);
           n := 0
         end;
         last := this;
-        T.output level facil (T.format level facil str);
+        t.output level facil (t.format level facil ts pairs str);
       end
+  in { put }
 
-end
+(** A logger *)
+type t = {
+  debug_s: facil -> Time.t -> Pairs.t -> string -> unit;
+  info_s: facil -> Time.t -> Pairs.t -> string -> unit;
+  warn_s: facil -> Time.t -> Pairs.t -> string -> unit;
+  error_s: facil -> Time.t -> Pairs.t -> string -> unit;
+  critical_s: facil -> Time.t -> Pairs.t -> string -> unit;
+  put_s: level -> facil -> Time.t -> Pairs.t -> string -> unit;
+  debug: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
+  info: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
+  warn: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
+  error: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
+  critical: 'a. facil -> Time.t -> Pairs.t -> ('a, unit, string, unit) format4 -> 'a;
+}
 
-module Make(T : Put) = struct
-
-  let debug_s = T.put `Debug
-  let info_s = T.put `Info
-  let warn_s = T.put `Warn
-  let error_s = T.put `Error
-  let critical_s = T.put `Critical
-  let put_s = T.put
-
-  let debug f fmt = ksprintf (debug_s f) fmt
-  let info f fmt = ksprintf (info_s f) fmt
-  let warn f fmt = ksprintf (warn_s f) fmt
-  let error f fmt = ksprintf (error_s f) fmt
-  let critical f fmt = ksprintf (critical_s f) fmt
-
-end
+let make (t:put) : t =
+  let debug_s = t.put `Debug in
+  let info_s = t.put `Info in
+  let warn_s = t.put `Warn in
+  let error_s = t.put `Error in
+  let critical_s = t.put `Critical in
+  let put_s = t.put in
+  let debug f ts pairs fmt = ksprintf (debug_s f ts pairs) fmt in
+  let info f ts pairs fmt = ksprintf (info_s f ts pairs) fmt in
+  let warn f ts pairs fmt = ksprintf (warn_s f ts pairs) fmt in
+  let error f ts pairs fmt = ksprintf (error_s f ts pairs) fmt in
+  let critical f ts pairs fmt = ksprintf (critical_s f ts pairs) fmt in
+  { debug_s; info_s; warn_s; error_s; critical_s; put_s; debug; info; warn; error; critical }

--- a/test.ml
+++ b/test.ml
@@ -595,6 +595,69 @@ let () =
   assert_equal !accumulator 4;
   ()
 
+let () = test "Logfmt" begin fun () ->
+  let eq name expected got =
+    assert_equal ~msg:name ~printer:(fun s -> sprintf "%S" s) expected got
+  in
+  eq "empty" "" (Logfmt.to_string []);
+  eq "safe" "k=v" (Logfmt.to_string ["k","v"]);
+  eq "multiple" "a=1 b=2" (Logfmt.to_string [("a","1");("b","2")]);
+  eq "empty value" "k=" (Logfmt.to_string ["k",""]);
+  eq "space" {|k="hello world"|} (Logfmt.to_string ["k","hello world"]);
+  eq "newline" {|k="a\nb"|} (Logfmt.to_string ["k","a\nb"]);
+  eq "quote" {|k="a\"b"|} (Logfmt.to_string ["k","a\"b"]);
+  eq "backslash" {|k="a\\b"|} (Logfmt.to_string ["k","a\\b"]);
+  eq "utf8" {|k="é"|} (Logfmt.to_string ["k","é"]);
+end
+
+let with_log_hook f =
+  let buf = Buffer.create 128 in
+  let prev = !Log.State.hook in
+  Log.State.hook := (fun _ _ s -> Buffer.add_string buf s);
+  Std.finally (fun () -> Log.State.hook := prev) f ();
+  buf
+
+let () = test "Log.pairs" begin fun () ->
+  let prev_utc = !Log.State.utc_timezone in
+  Log.State.utc_timezone := true;
+  Std.finally (fun () -> Log.State.utc_timezone := prev_utc) (fun () ->
+    let ts = 1700000000. in (* 2023-11-14 22:13:20 UTC *)
+    let log = Log.from "logtest" in
+    let check ~msg ~suffix out =
+      assert_bool (sprintf "%s: expected suffix %S, got %S" msg suffix out)
+        (Stre.ends_with out suffix)
+    in
+    let run action =
+      let out = Buffer.contents (with_log_hook action) in
+      assert_bool ("facility in output: " ^ out) (Stre.exists out "[logtest:");
+      assert_bool ("ts in output: " ^ out) (Stre.exists out "2023-11-14");
+      out
+    in
+    let out = run (fun () -> log#info ~ts ~pairs:["k","v"] "hello %d" 42) in
+    check ~msg:"pairs suffix" ~suffix:" hello 42 k=v\n" out;
+    let out = run (fun () -> log#info ~ts "plain") in
+    check ~msg:"no pairs" ~suffix:" plain\n" out;
+    let out = run (fun () -> log#warn ~ts ~pairs:[("a","1");("quoted","he said \"hi\"")] "m") in
+    check ~msg:"escape+multi" ~suffix:({| m a=1 quoted="he said \"hi\""|} ^ "\n") out;
+    assert_bool ("warn level: " ^ out) (Stre.exists out "[logtest:warn]")
+  ) ()
+end
+
+let () = test "Log.filter" begin fun () ->
+  let log = Log.from "filtertest" in
+  let prev_level = log#level in
+  log#allow `Warn;
+  Std.finally (fun () -> log#allow prev_level) (fun () ->
+    let buf = with_log_hook (fun () ->
+      log#info "suppressed";
+      log#warn "kept"
+    ) in
+    let out = Buffer.contents buf in
+    assert_bool ("only warn survives: " ^ out) (not (Stre.exists out "suppressed"));
+    assert_bool ("warn kept: " ^ out) (Stre.exists out "kept")
+  ) ()
+end
+
 let tests () =
   let (_:test_results) = run_test_tt_main ("devkit" >::: List.rev !tests) in
   ()

--- a/web.ml
+++ b/web.ml
@@ -238,28 +238,36 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
 
   let verbose_curl_result nr_http action t h code =
     let open Curl in
-    let b = Buffer.create 10 in
-    bprintf b "%s #%d %s ⇓%s ⇑%s %s "
-      (string_of_http_action action) nr_http (Time.compact_duration t#get)
-      (Action.bytes_string_f @@ get_sizedownload h)
-      (Action.bytes_string_f @@ get_sizeupload h)
-      (get_primaryip h)
-    ;
-    begin match code with
+    let size_down = get_sizedownload h in
+    let size_up = get_sizeupload h in
+    let base = [
+      "method", string_of_http_action action;
+      "http_seq", string_of_int nr_http;
+      "duration", sprintf "%.3f" t#get;
+      "size_down", Action.bytes_string_f size_down;
+      "size_down_raw", sprintf "%.0f" size_down;
+      "size_up", Action.bytes_string_f size_up;
+      "size_up_raw", sprintf "%.0f" size_up;
+      "ip", get_primaryip h;
+    ] in
+    let base = match get_httpcode h with
+      | 0 -> base
+      | n -> ("http_status", string_of_int n) :: base
+    in
+    match code with
     | CURLE_OK ->
-      bprintf b "HTTP %d %s" (get_httpcode h) (get_effectiveurl h);
-      begin match get_redirecturl h with
-      | "" -> ()
-      | s -> bprintf b " -> %s" s
-      end;
-      begin match get_redirectcount h with
-      | 0 -> ()
-      | n -> bprintf b " after %d redirects" n
-      end
+      let pairs = ("url", get_effectiveurl h) :: base in
+      let pairs = match get_redirecturl h with "" -> pairs | s -> ("redirect", s) :: pairs in
+      let pairs = match get_redirectcount h with 0 -> pairs | n -> ("redirect_count", string_of_int n) :: pairs in
+      log #info ~pairs "http done"
     | _ ->
-      bprintf b "error (%d) %s (errno %d)" (errno code) (strerror code) (Curl.get_oserrno h)
-    end;
-    log #info_s (Buffer.contents b)
+      let pairs =
+        ("err", strerror code) ::
+        ("errno", string_of_int (errno code)) ::
+        ("oserrno", string_of_int (get_oserrno h)) ::
+        base
+      in
+      log #info ~pairs "http error"
 
   (* Given a list of strings, check pre-existing entry starting with `~name`; and adds the concatenation of `~name` and `~value` if not. *)
   let add_if_absent ~name ~value strs =
@@ -320,7 +328,13 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       | Some (`Raw (ct,body)) -> sprintf "%s \"%s\"" ct (Stre.shorten ~escape:true 64 body)
       | Some (`Chunked (ct,_f)) -> sprintf "%s chunked" ct
       in
-      log #info "%s #%d %s %s" action_name nr_http url body
+      let pairs = [
+        "method", action_name;
+        "http_seq", string_of_int nr_http;
+        "url", url;
+      ] in
+      let pairs = if body = "" then pairs else ("body", body) :: pairs in
+      log #info ~pairs "http start"
     end;
 
     let describe () =

--- a/web.ml
+++ b/web.ml
@@ -358,13 +358,17 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       | Some (`Raw (ct,body)) -> sprintf "%s \"%s\"" ct (Stre.shorten ~escape:true 64 body)
       | Some (`Chunked (ct,_f)) -> sprintf "%s chunked" ct
       in
-      let pairs = [
-        "method", action_name;
-        "http_seq", string_of_int nr_http;
-        "url", url;
-      ] in
-      let pairs = if body = "" then pairs else ("body", body) :: pairs in
-      log #info ~pairs "http start"
+
+      match Log.State.get_cur_format () with
+      | `Plain, _ -> log #info "%s #%d %s %s" action_name nr_http url body
+      | `Logfmt, _ ->
+        let pairs = [
+          "method", action_name;
+          "http_seq", string_of_int nr_http;
+          "url", url;
+        ] in
+        let pairs = if body = "" then pairs else ("body", body) :: pairs in
+        log #info ~pairs "http start"
     end;
 
     let describe () =

--- a/web.ml
+++ b/web.ml
@@ -359,16 +359,12 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       | Some (`Chunked (ct,_f)) -> sprintf "%s chunked" ct
       in
 
-      match Log.State.get_cur_format () with
-      | `Plain, _ -> log #info "%s #%d %s %s" action_name nr_http url body
-      | `Logfmt, _ ->
-        let pairs = [
-          "method", action_name;
-          "http_seq", string_of_int nr_http;
-          "url", url;
-        ] in
-        let pairs = if body = "" then pairs else ("body", body) :: pairs in
-        log #info ~pairs "http start"
+      let structured_pairs = [
+        "method", action_name;
+        "http_seq", string_of_int nr_http;
+        "url", url;
+      ] in
+      log #info "%s #%d %s %s" action_name nr_http url body ~structured_pairs
     end;
 
     let describe () =

--- a/web.ml
+++ b/web.ml
@@ -236,7 +236,32 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
       | code -> `Error code
     end
 
-  let verbose_curl_result nr_http action t h code =
+  let verbose_curl_result_plain nr_http action t h code =
+    let open Curl in
+    let b = Buffer.create 10 in
+    bprintf b "%s #%d %s ⇓%s ⇑%s %s "
+      (string_of_http_action action) nr_http (Time.compact_duration t#get)
+      (Action.bytes_string_f @@ get_sizedownload h)
+      (Action.bytes_string_f @@ get_sizeupload h)
+      (get_primaryip h)
+    ;
+    begin match code with
+    | CURLE_OK ->
+      bprintf b "HTTP %d %s" (get_httpcode h) (get_effectiveurl h);
+      begin match get_redirecturl h with
+      | "" -> ()
+      | s -> bprintf b " -> %s" s
+      end;
+      begin match get_redirectcount h with
+      | 0 -> ()
+      | n -> bprintf b " after %d redirects" n
+      end
+    | _ ->
+      bprintf b "error (%d) %s (errno %d)" (errno code) (strerror code) (Curl.get_oserrno h)
+    end;
+    log #info_s (Buffer.contents b)
+
+  let verbose_curl_result_logfmt nr_http action t h code =
     let open Curl in
     let size_down = get_sizedownload h in
     let size_up = get_sizeupload h in
@@ -268,6 +293,11 @@ module Http (IO : IO_TYPE) (Curl_IO : CURL with type 'a t = 'a IO.t) : HTTP with
         base
       in
       log #info ~pairs "http error"
+
+  let verbose_curl_result nr_http action t h code =
+    match Log.State.get_cur_format () with
+    | `Plain, _ -> verbose_curl_result_plain nr_http action t h code
+    | `Logfmt, _ -> verbose_curl_result_logfmt nr_http action t h code
 
   (* Given a list of strings, check pre-existing entry starting with `~name`; and adds the concatenation of `~name` and `~value` if not. *)
   let add_if_absent ~name ~value strs =


### PR DESCRIPTION
- modifies how loggers work so it's easier to swap them at runtime
- pass timestamp and a list of key/value pairs
- normal callsites for logging are unaffected, but it enables us to have richer logging.